### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Therefore I decided to write an own, final implementation which meets the follow
  - Support of decimal/floating number representation (with an own fast itoa/ftoa)
  - Reentrant and thread-safe, malloc free, no static vars/buffers
  - LINT and compiler L4 warning free, mature, coverity clean, automotive ready
- - Extensive test suite (> 340 test cases) passing
+ - Extensive test suite (> 350 test cases) passing
  - Simply the best *printf* around the net
  - MIT license
 

--- a/printf.c
+++ b/printf.c
@@ -649,7 +649,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 
       case 's' : {
         char* p = va_arg(va, char*);
-        unsigned int l = _strlen(p);
+        unsigned int l = _strlen(p, precision);
         // pre padding
         if (flags & FLAGS_PRECISION) {
           l = (l < precision ? l : precision);

--- a/printf.c
+++ b/printf.c
@@ -141,10 +141,12 @@ static inline void _out_fct(char character, void* buffer, size_t idx, size_t max
 
 // internal strlen
 // \return The length of the string (excluding the terminating 0)
-static inline unsigned int _strlen(const char* str)
+//         limited by 'max' size if non-zero
+static inline unsigned int _strlen(const char* str, size_t max)
 {
   const char* s;
-  for (s = str; *s; ++s);
+  size_t n = max;
+  for (s = str; *s && (max?n--:1); ++s);
   return (unsigned int)(s - str);
 }
 

--- a/printf.c
+++ b/printf.c
@@ -139,14 +139,13 @@ static inline void _out_fct(char character, void* buffer, size_t idx, size_t max
 }
 
 
-// internal strlen
+// internal secure strlen
 // \return The length of the string (excluding the terminating 0)
 //         limited by 'max' size if non-zero
-static inline unsigned int _strlen(const char* str, size_t max)
+static inline unsigned int _strnlen_s(const char* str, size_t maxsize)
 {
   const char* s;
-  size_t n = max;
-  for (s = str; *s && (max?n--:1); ++s);
+  for (s = str; *s && maxsize--; ++s);
   return (unsigned int)(s - str);
 }
 
@@ -649,7 +648,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 
       case 's' : {
         char* p = va_arg(va, char*);
-        unsigned int l = _strlen(p, precision);
+        unsigned int l = _strnlen_s(p, precision ? precision : (size_t)-1);
         // pre padding
         if (flags & FLAGS_PRECISION) {
           l = (l < precision ? l : precision);

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -1187,6 +1187,32 @@ TEST_CASE("unknown flag", "[]" ) {
 }
 
 
+TEST_CASE("string length", "[]" ) {
+  char buffer[100];
+
+  test::sprintf(buffer, "%.4s", "This is a test");
+  REQUIRE(!strcmp(buffer, "This"));
+
+  test::sprintf(buffer, "%.4s", "test");
+  REQUIRE(!strcmp(buffer, "test"));
+
+  test::sprintf(buffer, "%.7s", "123");
+  REQUIRE(!strcmp(buffer, "123"));
+
+  test::sprintf(buffer, "%.7s", "");
+  REQUIRE(!strcmp(buffer, ""));
+
+  test::sprintf(buffer, "%.4s%.2s", "123456", "abcdef");
+  REQUIRE(!strcmp(buffer, "1234ab"));
+
+  test::sprintf(buffer, "%.4.2s", "123456");
+  REQUIRE(!strcmp(buffer, ".2s"));
+
+  test::sprintf(buffer, "%.*s", 3, "123456");
+  REQUIRE(!strcmp(buffer, "123"));
+}
+
+
 TEST_CASE("buffer length", "[]" ) {
   char buffer[100];
   int ret;


### PR DESCRIPTION
I wanted the limit specifier for strings (e.g. "%16.s") to be usable in situations when zero termination isn't guaranteed. Otherwise it may end up crashing. As a simple fix I added lenght limitation to _strlen.