### PR TITLE
Suggested fix for issue #40

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -178,6 +178,9 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
 
   // pad leading zeros
   if (!(flags & FLAGS_LEFT)) {
+    if (width && (flags & FLAGS_ZEROPAD) && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
+      width--;
+    }
     while ((len < prec) && (len < PRINTF_NTOA_BUFFER_SIZE)) {
       buf[len++] = '0';
     }
@@ -208,10 +211,6 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
     }
   }
 
-  // handle sign
-  if (len && (len == width) && (negative || (flags & FLAGS_PLUS) || (flags & FLAGS_SPACE))) {
-    len--;
-  }
   if (len < PRINTF_NTOA_BUFFER_SIZE) {
     if (negative) {
       buf[len++] = '-';
@@ -395,15 +394,14 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 
   // pad leading zeros
   if (!(flags & FLAGS_LEFT) && (flags & FLAGS_ZEROPAD)) {
+    if (width && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
+      width--;
+    }
     while ((len < width) && (len < PRINTF_FTOA_BUFFER_SIZE)) {
       buf[len++] = '0';
     }
   }
 
-  // handle sign
-  if ((len == width) && (negative || (flags & FLAGS_PLUS) || (flags & FLAGS_SPACE))) {
-    len--;
-  }
   if (len < PRINTF_FTOA_BUFFER_SIZE) {
     if (negative) {
       buf[len++] = '-';

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -864,6 +864,74 @@ TEST_CASE("padding 20.5", "[]" ) {
   REQUIRE(!strcmp(buffer, "          00EDCB5433"));
 }
 
+TEST_CASE("padding neg numbers", "[]" ) {
+  char buffer[100];
+  
+  // space padding
+  
+  test::sprintf(buffer, "% 1d", -5);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "% 2d", -5);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "% 3d", -5);
+  REQUIRE(!strcmp(buffer, " -5"));
+  
+  test::sprintf(buffer, "% 4d", -5);
+  REQUIRE(!strcmp(buffer, "  -5"));
+  
+  // zero padding
+  
+  test::sprintf(buffer, "%01d", -5);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "%02d", -5);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "%03d", -5);
+  REQUIRE(!strcmp(buffer, "-05"));
+  
+  test::sprintf(buffer, "%04d", -5);
+  REQUIRE(!strcmp(buffer, "-005"));
+}
+
+TEST_CASE("float padding neg numbers", "[]" ) {
+  char buffer[100];
+
+  // space padding
+  
+  test::sprintf(buffer, "% 3.1f", -5.);
+  REQUIRE(!strcmp(buffer, "-5.0"));
+  
+  test::sprintf(buffer, "% 4.1f", -5.);
+  REQUIRE(!strcmp(buffer, "-5.0"));
+  
+  test::sprintf(buffer, "% 5.1f", -5.);
+  REQUIRE(!strcmp(buffer, " -5.0"));
+  
+  // zero padding
+  
+  test::sprintf(buffer, "%03.1f", -5.);
+  REQUIRE(!strcmp(buffer, "-5.0"));
+  
+  test::sprintf(buffer, "%04.1f", -5.);
+  REQUIRE(!strcmp(buffer, "-5.0"));
+  
+  test::sprintf(buffer, "%05.1f", -5.);
+  REQUIRE(!strcmp(buffer, "-05.0"));
+      
+  // zero padding no decimal point
+  
+  test::sprintf(buffer, "%01.0f", -5.);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "%02.0f", -5.);
+  REQUIRE(!strcmp(buffer, "-5"));
+  
+  test::sprintf(buffer, "%03.0f", -5.);
+  REQUIRE(!strcmp(buffer, "-05"));
+}
 
 TEST_CASE("length", "[]" ) {
   char buffer[100];


### PR DESCRIPTION
I believe this should resolve issue #40, although I am having trouble running check on my machine right now. The idea is to decrement the padding width before starting to pad instead of backtracking, because `(len == width)` is sometimes true even if no padding chars were written.