### PR TITLE
Add support for %e/%g formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Therefore I decided to write an own, final implementation which meets the follow
  - Support of decimal/floating number representation (with an own fast itoa/ftoa)
  - Reentrant and thread-safe, malloc free, no static vars/buffers
  - LINT and compiler L4 warning free, mature, coverity clean, automotive ready
- - Extensive test suite (> 370 test cases) passing
+ - Extensive test suite (> 390 test cases) passing
  - Simply the best *printf* around the net
  - MIT license
 
@@ -92,6 +92,8 @@ The following format specifiers are supported:
 | x      | Unsigned hexadecimal integer (lowercase) |
 | X      | Unsigned hexadecimal integer (uppercase) |
 | f or F | Decimal floating point |
+| e or E | Scientific-notation (exponential) floating point |
+| g or G | Scientific or decimal floating point |
 | c      | Single character |
 | s      | String of characters |
 | p      | Pointer address |
@@ -164,6 +166,7 @@ int length = sprintf(NULL, "Hello, world"); // length is set to 12
 | PRINTF_NTOA_BUFFER_SIZE          | 32        | ntoa (integer) conversion buffer size. This must be big enough to hold one converted numeric number _including_ leading zeros, normally 32 is a sufficient value. Created on the stack |
 | PRINTF_FTOA_BUFFER_SIZE          | 32        | ftoa (float) conversion buffer size. This must be big enough to hold one converted float number _including_ leading zeros, normally 32 is a sufficient value. Created on the stack |
 | PRINTF_DISABLE_SUPPORT_FLOAT     | undefined | Define this to disable floating point (%f) support |
+| PRINTF_DISABLE_SUPPORT_EXPONENTIAL | undefined | Define this to disable exponential floating point (%e) support |
 | PRINTF_DISABLE_SUPPORT_LONG_LONG | undefined | Define this to disable long long (%ll) support |
 | PRINTF_DISABLE_SUPPORT_PTRDIFF_T | undefined | Define this to disable ptrdiff_t (%t) support |
 

--- a/printf.c
+++ b/printf.c
@@ -106,7 +106,7 @@
 #define FLAGS_LONG      (1U <<  8U)
 #define FLAGS_LONG_LONG (1U <<  9U)
 #define FLAGS_PRECISION (1U << 10U)
-#define FLAGS_ADAPT_EXP	(1U << 11U)
+#define FLAGS_ADAPT_EXP (1U << 11U)
 
 
 // output function type
@@ -337,7 +337,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   if (value < -DBL_MAX)
     return _out_rev(out, buffer, idx, maxlen, "fni-", 4, width, flags);
   if (value > DBL_MAX)
-	return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4 : 3, width, flags);
+    return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4 : 3, width, flags);
 
   // test for very large values
   // standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad
@@ -456,14 +456,14 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 {
   // check for special values
   if ((value != value)||(value > DBL_MAX)||(value < -DBL_MAX))
-	return _ftoa(out, buffer, idx, maxlen, value, prec, width, flags);
+    return _ftoa(out, buffer, idx, maxlen, value, prec, width, flags);
   
   // determine the sign
   bool negative = value < 0;
   if (negative) value = -value;
 
   // determine the decimal exponent
-  int expval = (int)floor(log10(value));	// "value" must be +ve
+  int expval = (int)floor(log10(value));    // "value" must be +ve
 
   // the exponent format is "%+03d" and largest value is "307", so set aside 4-5 characters
   unsigned int minwidth = ((expval < 100)&&(expval > -100)) ? 4 : 5;
@@ -475,23 +475,23 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   
   // in "%g" mode, "prec" is the number of *significant figures* not decimals
   if (flags & FLAGS_ADAPT_EXP) {
-	// do we want to fall-back to "%f" mode for small number?
-	if ((expval > -5)&&(expval < 6)) {
-	  if ((int)prec > expval) {
-		prec = (unsigned)((int)prec - expval - 1);
+    // do we want to fall-back to "%f" mode for small number?
+    if ((expval > -5)&&(expval < 6)) {
+      if ((int)prec > expval) {
+        prec = (unsigned)((int)prec - expval - 1);
       } else {
-		prec = 0;
-	  }
-	  // TODO: there's also a special case where we're supposed to ELIMINATE digits from the whole part
-	  flags |= FLAGS_PRECISION; // make sure _ftoa respects precision
-	  
-	  // no characters in exponent
-	  minwidth = 0;
-	  expval = 0;
-	} else {
-	  // we use one sigfig for the whole part
-	  if ((prec > 0)&&(flags & FLAGS_PRECISION)) --prec;
-	}
+        prec = 0;
+      }
+      // TODO: there's also a special case where we're supposed to ELIMINATE digits from the whole part
+      flags |= FLAGS_PRECISION; // make sure _ftoa respects precision
+      
+      // no characters in exponent
+      minwidth = 0;
+      expval = 0;
+    } else {
+      // we use one sigfig for the whole part
+      if ((prec > 0)&&(flags & FLAGS_PRECISION)) --prec;
+    }
   }
   // will everything fit?
   unsigned int fwidth = width;
@@ -499,12 +499,12 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
     // we didn't fall-back so subtract the characters required for the exponent
     fwidth -= minwidth;
   } else {
-	// not enough characters, so go back to default sizing
-	fwidth = 0;
+    // not enough characters, so go back to default sizing
+    fwidth = 0;
   }
   if ((flags & FLAGS_LEFT) && minwidth) {
-	// if we're padding on the right, DON'T pad the floating part
-	fwidth = 0;
+    // if we're padding on the right, DON'T pad the floating part
+    fwidth = 0;
   }
 
   // rescale the float value
@@ -516,14 +516,14 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 
   // output the exponent part
   if (minwidth) {
-	// output the exponential symbol
-	out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
-	// output the exponent value
-	idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
-	// might need to right-pad spaces
-	if (flags & FLAGS_LEFT) {
-		while (idx - start_idx < width) out(' ', buffer, idx++, maxlen);
-	}
+    // output the exponential symbol
+    out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
+    // output the exponent value
+    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
+    // might need to right-pad spaces
+    if (flags & FLAGS_LEFT) {
+      while (idx - start_idx < width) out(' ', buffer, idx++, maxlen);
+    }
   }
   return idx;
 }
@@ -716,20 +716,20 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 #if defined(PRINTF_SUPPORT_FLOAT)
       case 'f' :
       case 'F' :
-	    if (*format == 'F') flags |= FLAGS_UPPERCASE;
+        if (*format == 'F') flags |= FLAGS_UPPERCASE;
         idx = _ftoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
         format++;
         break;
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
       case 'e':
-	  case 'E':
+      case 'E':
       case 'g':
-	  case 'G':
-	    if ((*format == 'g')||(*format == 'G')) flags |= FLAGS_ADAPT_EXP;
-		if ((*format == 'E')||(*format == 'G')) flags |= FLAGS_UPPERCASE;
-	    idx = _etoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
-		format++;
-		break;
+      case 'G':
+        if ((*format == 'g')||(*format == 'G')) flags |= FLAGS_ADAPT_EXP;
+        if ((*format == 'E')||(*format == 'G')) flags |= FLAGS_UPPERCASE;
+        idx = _etoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
+        format++;
+        break;
 #endif  // PRINTF_SUPPORT_EXPONENTIAL
 #endif  // PRINTF_SUPPORT_FLOAT
       case 'c' : {

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -1045,9 +1045,19 @@ TEST_CASE("length", "[]" ) {
 TEST_CASE("float", "[]" ) {
   char buffer[100];
 
-  test::sprintf(buffer, "%8f", NAN);   // using the NAN macro of math.h
+  // test special-case floats using math.h macros
+  test::sprintf(buffer, "%8f", NAN);
   REQUIRE(!strcmp(buffer, "     nan"));
 
+  test::sprintf(buffer, "%8f", INFINITY);
+  REQUIRE(!strcmp(buffer, "     inf"));
+
+  test::sprintf(buffer, "%-8f", -INFINITY);
+  REQUIRE(!strcmp(buffer, "-inf    "));
+
+  test::sprintf(buffer, "%+8e", INFINITY);
+  REQUIRE(!strcmp(buffer, "    +inf"));
+  
   test::sprintf(buffer, "%.4f", 3.1415354);
   REQUIRE(!strcmp(buffer, "3.1415"));
 

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -346,6 +346,13 @@ TEST_CASE("- flag", "[]" ) {
 
   test::sprintf(buffer, "%0-15d", -42);
   REQUIRE(!strcmp(buffer, "-42            "));
+  
+  test::sprintf(buffer, "%0-15.3e", -42.);
+  REQUIRE(!strcmp(buffer, "-4.200e+01     "));
+  
+  test::sprintf(buffer, "%0-15.3g", -42.);
+  REQUIRE(!strcmp(buffer, "-42.0          "));
+  
 }
 
 
@@ -911,6 +918,15 @@ TEST_CASE("float padding neg numbers", "[]" ) {
   test::sprintf(buffer, "% 5.1f", -5.);
   REQUIRE(!strcmp(buffer, " -5.0"));
   
+  test::sprintf(buffer, "% 6.1g", -5.);
+  REQUIRE(!strcmp(buffer, "    -5"));
+  
+  test::sprintf(buffer, "% 6.1e", -5.);
+  REQUIRE(!strcmp(buffer, "-5.0e+00"));
+  
+  test::sprintf(buffer, "% 10.1e", -5.);
+  REQUIRE(!strcmp(buffer, "  -5.0e+00"));
+  
   // zero padding
   
   test::sprintf(buffer, "%03.1f", -5.);
@@ -921,6 +937,9 @@ TEST_CASE("float padding neg numbers", "[]" ) {
   
   test::sprintf(buffer, "%05.1f", -5.);
   REQUIRE(!strcmp(buffer, "-05.0"));
+  
+  test::sprintf(buffer, "%010.1e", -5.);
+  REQUIRE(!strcmp(buffer, "-005.0e+00"));
       
   // zero padding no decimal point
   
@@ -931,6 +950,12 @@ TEST_CASE("float padding neg numbers", "[]" ) {
   REQUIRE(!strcmp(buffer, "-5"));
   
   test::sprintf(buffer, "%03.0f", -5.);
+  REQUIRE(!strcmp(buffer, "-05"));
+  
+  test::sprintf(buffer, "%07.0E", -5.);
+  REQUIRE(!strcmp(buffer, "-05E+00"));
+  
+  test::sprintf(buffer, "%03.0g", -5.);
   REQUIRE(!strcmp(buffer, "-05"));
 }
 
@@ -1020,8 +1045,8 @@ TEST_CASE("length", "[]" ) {
 TEST_CASE("float", "[]" ) {
   char buffer[100];
 
-  test::sprintf(buffer, "%.4f", NAN);   // using the NAN macro of math.h
-  REQUIRE(!strcmp(buffer, "nan"));
+  test::sprintf(buffer, "%8f", NAN);   // using the NAN macro of math.h
+  REQUIRE(!strcmp(buffer, "     nan"));
 
   test::sprintf(buffer, "%.4f", 3.1415354);
   REQUIRE(!strcmp(buffer, "3.1415"));
@@ -1090,9 +1115,39 @@ TEST_CASE("float", "[]" ) {
   test::sprintf(buffer, "a%-5.1fend", 0.5);
   REQUIRE(!strcmp(buffer, "a0.5  end"));
 
-  // out of range in the moment, need to be fixed by someone
+  test::sprintf(buffer, "%G", 12345.678);
+  REQUIRE(!strcmp(buffer, "12345.7"));
+  
+  test::sprintf(buffer, "%.7G", 12345.678);
+  REQUIRE(!strcmp(buffer, "12345.68"));
+  
+  test::sprintf(buffer, "%.5G", 123456789.);
+  REQUIRE(!strcmp(buffer, "1.2346E+08"));
+  
+  test::sprintf(buffer, "%.6G", 12345.);
+  REQUIRE(!strcmp(buffer, "12345.0"));
+  
+  test::sprintf(buffer, "%+12.4g", 123456789.);
+  REQUIRE(!strcmp(buffer, "  +1.235e+08"));
+  
+  test::sprintf(buffer, "%.2G", 0.001234);
+  REQUIRE(!strcmp(buffer, "0.0012"));
+  
+  test::sprintf(buffer, "%+10.4G", 0.001234);
+  REQUIRE(!strcmp(buffer, " +0.001234"));
+  
+  test::sprintf(buffer, "%+012.4g", 0.00001234);
+  REQUIRE(!strcmp(buffer, "+001.234e-05"));
+  
+  test::sprintf(buffer, "%.3g", -1.2345e-308);
+  REQUIRE(!strcmp(buffer, "-1.23e-308"));
+  
+  test::sprintf(buffer, "%+.3E", 1.23e+308);
+  REQUIRE(!strcmp(buffer, "+1.230E+308"));
+  
+  // out of range for float: should switch to exp notation
   test::sprintf(buffer, "%.1f", 1E20);
-  REQUIRE(!strcmp(buffer, ""));
+  REQUIRE(!strcmp(buffer, "1.0e+20"));
 }
 
 
@@ -1346,6 +1401,12 @@ TEST_CASE("misc", "[]" ) {
   test::sprintf(buffer, "%.*f", 2, 0.33333333);
   REQUIRE(!strcmp(buffer, "0.33"));
 
+  test::sprintf(buffer, "%.*g", 2, 0.33333333);
+  REQUIRE(!strcmp(buffer, "0.33"));
+  
+  test::sprintf(buffer, "%.*e", 2, 0.33333333);
+  REQUIRE(!strcmp(buffer, "3.33e-01"));
+  
   test::sprintf(buffer, "%.*d", -1, 1);
   REQUIRE(!strcmp(buffer, "1"));
 


### PR DESCRIPTION
Implemented exponential/scientific formatting for floating-point numbers, of both %e and %g varieties. Obeys the main features of the standard library implementation as demonstrated by the test cases added to the suite.

Addresses issue #30 by use of a PRINTF_MAX_FLOAT value which causes %f to switch to %e (previously unimplemented).

%g implementation obeys requirements about significant figures, and switches back to %f for "small" values as chosen based on testing the libc implementation.

Also includes fixes for special cases NAN, +INF and -INF (supporting padding as necessary).

Current implementation requires the use of log10 from <math.h>, but in principle fancier bit-manipulation tricks could be used instead. These addition dependency may be undesirable in some applications so a PRINTF_SUPPORT_EXPONENTIAL inclusion guard is used.

Thanks for any feedback.