### PR TITLE
Unittest redesign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ APP = test_suite
 #              bar/file3
 # -----------------------------------------------------------------------------
 
-FILES_PRJ  = test/test_suite
+FILES_PRJ  = test/test_suite printf
 
 
 # ------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ VPATH := $(sort $(dir $(FILES_TMP)))
 # ------------------------------------------------------------------------------
 AR        = $(PATH_TOOLS_CC)ar
 AS        = $(PATH_TOOLS_CC)g++
-CC        = $(PATH_TOOLS_CC)g++
+CC        = $(PATH_TOOLS_CC)gcc
 CL        = $(PATH_TOOLS_CC)g++
 NM        = $(PATH_TOOLS_CC)nm
 GCOV      = $(PATH_TOOLS_CC)gcov
@@ -107,7 +107,6 @@ SED       = $(PATH_TOOLS_UTIL)sed
 
 GCCFLAGS      = $(C_INCLUDES)                     \
                 $(C_DEFINES)                      \
-                -std=c++11                        \
                 -g                                \
                 -Wall                             \
                 -pedantic                         \
@@ -124,10 +123,8 @@ GCCFLAGS      = $(C_INCLUDES)                     \
                 -Winit-self                       \
                 -Wdouble-promotion                \
                 -gdwarf-2                         \
-                -fno-exceptions                   \
                 -O2                               \
                 -ffunction-sections               \
-                -ffat-lto-objects                 \
                 -fdata-sections                   \
                 -fverbose-asm                     \
                 -Wextra                           \
@@ -135,12 +132,12 @@ GCCFLAGS      = $(C_INCLUDES)                     \
                 -Wfloat-equal
 
 CFLAGS        = $(GCCFLAGS)                       \
-                -Wunsuffixed-float-constants      \
                 -x c                              \
                 -std=c99
 
 CPPFLAGS      = $(GCCFLAGS)                       \
                 -x c++                            \
+                -std=c++11                        \
                 -fno-rtti                         \
                 -fstrict-enums                    \
                 -fno-use-cxa-atexit               \
@@ -269,3 +266,4 @@ $(TRG)_nm.txt : $(TRG)
 	@-$(SED) -e 's|.h:\([0-9]*\),|.h(\1) :|' -e 's|:\([0-9]*\):|(\1) :|' $(PATH_ERR)/$(basename $(@F)).err
 	@-$(OBJDUMP) -S $(PATH_OBJ)/$(basename $(@F)).o > $(PATH_LST)/$(basename $(@F)).lst
 	@-$(CC) $(CFLAGS) $< -MM > $(PATH_OBJ)/$(basename $(@F)).d
+	@-$(CL) $(CFLAGS) -O0 --coverage $< -c -o $(PATH_COV)/$(basename $(@F)).o 2> $(PATH_NUL)

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -9599,6 +9599,15 @@ namespace Catch {
             }
             return names.substr(start, end - start + 1);
         };
+        auto skipq = [&] (size_t start, char quote) {
+            for (auto i = start + 1; i < names.size() ; ++i) {
+                if (names[i] == quote)
+                    return i;
+                if (names[i] == '\\')
+                    ++i;
+            }
+            assert(0 && "Mismatched quotes");
+        };
 
         size_t start = 0;
         std::stack<char> openings;
@@ -9618,6 +9627,10 @@ namespace Catch {
             case ')':
 //           case '>':
                 openings.pop();
+                break;
+            case '"':
+            case '\'':
+                pos = skipq(pos, c);
                 break;
             case ',':
                 if (start != pos && openings.size() == 0) {

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -34,19 +34,28 @@
 #include <sstream>
 #include <math.h>
 
+using Catch::Matchers::Equals;
 
-namespace test {
-  // use functions in own test namespace to avoid stdio conflicts
-  #include "../printf.h"
-  #include "../printf.c"
-} // namespace test
+// store pointers to library functions before they are masked by macro
+int (*lib_sprintf)(char * buffer, const char* fmt, ...) = sprintf;
+int (*lib_snprintf)(char * buffer, size_t count, const char* fmt, ...) = snprintf;
 
+#include "../printf.h"
+
+int (*our_sprintf)(char * buffer, const char* fmt, ...) = sprintf;
+int (*our_snprintf)(char * buffer, size_t count, const char* fmt, ...) = snprintf;
+
+
+// pointers to tested versions
+// allows running tests against standard library implementation
+int (*tested_sprintf)(char * buffer, const char* fmt, ...) = our_sprintf;
+int (*tested_snprintf)(char * buffer, size_t count, const char* fmt, ...) = our_snprintf;
 
 // dummy putchar
 static char   printf_buffer[100];
 static size_t printf_idx = 0U;
 
-void test::_putchar(char character)
+void _putchar(char character)
 {
   printf_buffer[printf_idx++] = character;
 }
@@ -57,11 +66,12 @@ void _out_fct(char character, void* arg)
   printf_buffer[printf_idx++] = character;
 }
 
+// run basic sanity tests
 
 TEST_CASE("printf", "[]" ) {
   printf_idx = 0U;
   memset(printf_buffer, 0xCC, 100U);
-  REQUIRE(test::printf("% d", 4232) == 5);
+  REQUIRE(printf("% d", 4232) == 5);
   REQUIRE(printf_buffer[5] == (char)0xCC);
   printf_buffer[5] = 0;
   REQUIRE(!strcmp(printf_buffer, " 4232"));
@@ -70,8 +80,9 @@ TEST_CASE("printf", "[]" ) {
 
 TEST_CASE("fctprintf", "[]" ) {
   printf_idx = 0U;
-  memset(printf_buffer, 0xCC, 100U);
-  test::fctprintf(&_out_fct, nullptr, "This is a test of %X", 0x12EFU);
+  memset(printf_buffer, 0xCC,  sizeof(printf_buffer));
+  int ret = fctprintf(&_out_fct, nullptr, "This is a test of %X", 0x12EFU);
+  REQUIRE(ret == 22U);
   REQUIRE(!strncmp(printf_buffer, "This is a test of 12EF", 22U));
   REQUIRE(printf_buffer[22] == (char)0xCC);
 }
@@ -79,19 +90,19 @@ TEST_CASE("fctprintf", "[]" ) {
 
 TEST_CASE("snprintf", "[]" ) {
   char buffer[100];
+  memset(buffer, 0xCC, sizeof(buffer));
+  snprintf(buffer, 100U, "%d", -1000);
+  REQUIRE_THAT(buffer, Equals("-1000"));
 
-  test::snprintf(buffer, 100U, "%d", -1000);
-  REQUIRE(!strcmp(buffer, "-1000"));
-
-  test::snprintf(buffer, 3U, "%d", -1000);
-  REQUIRE(!strcmp(buffer, "-1"));
+  snprintf(buffer, 3U, "%d", -1000);
+  REQUIRE_THAT(buffer, Equals("-1"));
 }
 
 static void vprintf_builder_1(char* buffer, ...)
 {
   va_list args;
   va_start(args, buffer);
-  test::vprintf("%d", args);
+  vprintf("%d", args);
   va_end(args);
 }
 
@@ -99,7 +110,7 @@ static void vsnprintf_builder_1(char* buffer, ...)
 {
   va_list args;
   va_start(args, buffer);
-  test::vsnprintf(buffer, 100U, "%d", args);
+  vsnprintf(buffer, 100U, "%d", args);
   va_end(args);
 }
 
@@ -107,7 +118,7 @@ static void vsnprintf_builder_3(char* buffer, ...)
 {
   va_list args;
   va_start(args, buffer);
-  test::vsnprintf(buffer, 100U, "%d %d %s", args);
+  vsnprintf(buffer, 100U, "%d %d %s", args);
   va_end(args);
 }
 
@@ -127,1089 +138,830 @@ TEST_CASE("vsnprintf", "[]" ) {
   char buffer[100];
 
   vsnprintf_builder_1(buffer, -1);
-  REQUIRE(!strcmp(buffer, "-1"));
+  REQUIRE_THAT(buffer, Equals("-1"));
 
   vsnprintf_builder_3(buffer, 3, -1000, "test");
-  REQUIRE(!strcmp(buffer, "3 -1000 test"));
+  REQUIRE_THAT(buffer, Equals("3 -1000 test"));
 }
+
+// macros to wrap tests
+// variables with result are available for further test cases
+#define TEST_DEF                                        \
+  char buffer[100];                                     \
+  int ret;                                              \
+  struct dummy                                          \
+  /**/
+
+#define TEST_SPRINTF(expected, ...)                     \
+  do {                                                  \
+    CAPTURE(__VA_ARGS__);                               \
+    ret = tested_sprintf(buffer, __VA_ARGS__);          \
+    CHECK_THAT(buffer, Equals(expected));               \
+    (void)ret;                                          \
+  } while (0)                                           \
+    /**/
+
+#define TEST_SNPRINTF(expected, retval, ...)            \
+  do {                                                  \
+    CAPTURE(__VA_ARGS__);                               \
+    ret = tested_snprintf(buffer, __VA_ARGS__);         \
+    if (expected)                                       \
+      CHECK_THAT(buffer, Equals(expected));             \
+    CHECK(ret == retval);                               \
+  } while (0)                                           \
+    /**/
+
 
 
 TEST_CASE("space flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "% d", 42);
-  REQUIRE(!strcmp(buffer, " 42"));
+  TEST_SPRINTF(" 42",
+               "% d", 42);
 
-  test::sprintf(buffer, "% d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "% 5d", 42);
-  REQUIRE(!strcmp(buffer, "   42"));
-
-  test::sprintf(buffer, "% 5d", -42);
-  REQUIRE(!strcmp(buffer, "  -42"));
-
-  test::sprintf(buffer, "% 15d", 42);
-  REQUIRE(!strcmp(buffer, "             42"));
-
-  test::sprintf(buffer, "% 15d", -42);
-  REQUIRE(!strcmp(buffer, "            -42"));
-
-  test::sprintf(buffer, "% 15d", -42);
-  REQUIRE(!strcmp(buffer, "            -42"));
-
-  test::sprintf(buffer, "% 15.3f", -42.987);
-  REQUIRE(!strcmp(buffer, "        -42.987"));
-
-  test::sprintf(buffer, "% 15.3f", 42.987);
-  REQUIRE(!strcmp(buffer, "         42.987"));
-
-  test::sprintf(buffer, "% s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "Hello testing"));
-
-  test::sprintf(buffer, "% d", 1024);
-  REQUIRE(!strcmp(buffer, " 1024"));
-
-  test::sprintf(buffer, "% d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "% i", 1024);
-  REQUIRE(!strcmp(buffer, " 1024"));
-
-  test::sprintf(buffer, "% i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "% u", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "% u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272"));
-
-  test::sprintf(buffer, "% o", 511);
-  REQUIRE(!strcmp(buffer, "777"));
-
-  test::sprintf(buffer, "% o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001"));
-
-  test::sprintf(buffer, "% x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd"));
-
-  test::sprintf(buffer, "% x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433"));
-
-  test::sprintf(buffer, "% X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD"));
-
-  test::sprintf(buffer, "% X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433"));
-
-  test::sprintf(buffer, "% c", 'x');
-  REQUIRE(!strcmp(buffer, "x"));
+  TEST_SPRINTF("-42",
+               "% d", -42);
+  TEST_SPRINTF("   42",
+               "% 5d", 42);
+  TEST_SPRINTF("  -42",
+               "% 5d", -42);
+  TEST_SPRINTF("             42",
+               "% 15d", 42);
+  TEST_SPRINTF("            -42",
+               "% 15d", -42);
+  TEST_SPRINTF("            -42",
+               "% 15d", -42);
+  TEST_SPRINTF("        -42.987",
+               "% 15.3f", -42.987);
+  TEST_SPRINTF("         42.987",
+               "% 15.3f", 42.987);
+  TEST_SPRINTF("Hello testing",
+               "% s", "Hello testing");
+  TEST_SPRINTF(" 1024",
+               "% d", 1024);
+  TEST_SPRINTF("-1024",
+               "% d", -1024);
+  TEST_SPRINTF(" 1024",
+               "% i", 1024);
+  TEST_SPRINTF("-1024",
+               "% i", -1024);
+  TEST_SPRINTF("1024",
+               "% u", 1024);
+  TEST_SPRINTF("4294966272",
+               "% u", 4294966272U);
+  TEST_SPRINTF("777",
+               "% o", 511);
+  TEST_SPRINTF("37777777001",
+               "% o", 4294966785U);
+  TEST_SPRINTF("1234abcd",
+               "% x", 305441741);
+  TEST_SPRINTF("edcb5433",
+               "% x", 3989525555U);
+  TEST_SPRINTF("1234ABCD",
+               "% X", 305441741);
+  TEST_SPRINTF("EDCB5433",
+               "% X", 3989525555U);
+  TEST_SPRINTF("x",
+               "% c", 'x');
 }
 
 
 TEST_CASE("+ flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%+d", 42);
-  REQUIRE(!strcmp(buffer, "+42"));
-
-  test::sprintf(buffer, "%+d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "%+5d", 42);
-  REQUIRE(!strcmp(buffer, "  +42"));
-
-  test::sprintf(buffer, "%+5d", -42);
-  REQUIRE(!strcmp(buffer, "  -42"));
-
-  test::sprintf(buffer, "%+15d", 42);
-  REQUIRE(!strcmp(buffer, "            +42"));
-
-  test::sprintf(buffer, "%+15d", -42);
-  REQUIRE(!strcmp(buffer, "            -42"));
-
-  test::sprintf(buffer, "%+s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "Hello testing"));
-
-  test::sprintf(buffer, "%+d", 1024);
-  REQUIRE(!strcmp(buffer, "+1024"));
-
-  test::sprintf(buffer, "%+d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%+i", 1024);
-  REQUIRE(!strcmp(buffer, "+1024"));
-
-  test::sprintf(buffer, "%+i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%+u", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%+u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272"));
-
-  test::sprintf(buffer, "%+o", 511);
-  REQUIRE(!strcmp(buffer, "777"));
-
-  test::sprintf(buffer, "%+o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001"));
-
-  test::sprintf(buffer, "%+x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd"));
-
-  test::sprintf(buffer, "%+x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433"));
-
-  test::sprintf(buffer, "%+X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD"));
-
-  test::sprintf(buffer, "%+X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433"));
-
-  test::sprintf(buffer, "%+c", 'x');
-  REQUIRE(!strcmp(buffer, "x"));
-
-  test::sprintf(buffer, "%+.0d", 0);
-  REQUIRE(!strcmp(buffer, "+"));
+  TEST_SPRINTF("+42",
+               "%+d", 42);
+  TEST_SPRINTF("-42",
+               "%+d", -42);
+  TEST_SPRINTF("  +42",
+               "%+5d", 42);
+  TEST_SPRINTF("  -42",
+               "%+5d", -42);
+  TEST_SPRINTF("            +42",
+               "%+15d", 42);
+  TEST_SPRINTF("            -42",
+               "%+15d", -42);
+  TEST_SPRINTF("Hello testing",
+               "%+s", "Hello testing");
+  TEST_SPRINTF("+1024",
+               "%+d", 1024);
+  TEST_SPRINTF("-1024",
+               "%+d", -1024);
+  TEST_SPRINTF("+1024",
+               "%+i", 1024);
+  TEST_SPRINTF("-1024",
+               "%+i", -1024);
+  TEST_SPRINTF("1024",
+               "%+u", 1024);
+  TEST_SPRINTF("4294966272",
+               "%+u", 4294966272U);
+  TEST_SPRINTF("777",
+               "%+o", 511);
+  TEST_SPRINTF("37777777001",
+               "%+o", 4294966785U);
+  TEST_SPRINTF("1234abcd",
+               "%+x", 305441741);
+  TEST_SPRINTF("edcb5433",
+               "%+x", 3989525555U);
+  TEST_SPRINTF("1234ABCD",
+               "%+X", 305441741);
+  TEST_SPRINTF("EDCB5433",
+               "%+X", 3989525555U);
+  TEST_SPRINTF("x",
+               "%+c", 'x');
+  TEST_SPRINTF("+",
+               "%+.0d", 0);
 }
 
 
 TEST_CASE("0 flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%0d", 42);
-  REQUIRE(!strcmp(buffer, "42"));
-
-  test::sprintf(buffer, "%0ld", 42L);
-  REQUIRE(!strcmp(buffer, "42"));
-
-  test::sprintf(buffer, "%0d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "%05d", 42);
-  REQUIRE(!strcmp(buffer, "00042"));
-
-  test::sprintf(buffer, "%05d", -42);
-  REQUIRE(!strcmp(buffer, "-0042"));
-
-  test::sprintf(buffer, "%015d", 42);
-  REQUIRE(!strcmp(buffer, "000000000000042"));
-
-  test::sprintf(buffer, "%015d", -42);
-  REQUIRE(!strcmp(buffer, "-00000000000042"));
-
-  test::sprintf(buffer, "%015.2f", 42.1234);
-  REQUIRE(!strcmp(buffer, "000000000042.12"));
-
-  test::sprintf(buffer, "%015.3f", 42.9876);
-  REQUIRE(!strcmp(buffer, "00000000042.988"));
-
-  test::sprintf(buffer, "%015.5f", -42.9876);
-  REQUIRE(!strcmp(buffer, "-00000042.98760"));
-}
+  TEST_SPRINTF("42",
+               "%0d", 42);
+  TEST_SPRINTF("42",
+               "%0ld", 42L);
+  TEST_SPRINTF("-42",
+               "%0d", -42);
+  TEST_SPRINTF("00042",
+               "%05d", 42);
+  TEST_SPRINTF("-0042",
+               "%05d", -42);
+  TEST_SPRINTF("000000000000042",
+               "%015d", 42);
+  TEST_SPRINTF("-00000000000042",
+               "%015d", -42);
+  TEST_SPRINTF("000000000042.12",
+               "%015.2f", 42.1234);
+  TEST_SPRINTF("00000000042.988",
+               "%015.3f", 42.9876);
+  TEST_SPRINTF("-00000042.98760",
+               "%015.5f", -42.9876);}
 
 
 TEST_CASE("- flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%-d", 42);
-  REQUIRE(!strcmp(buffer, "42"));
-
-  test::sprintf(buffer, "%-d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "%-5d", 42);
-  REQUIRE(!strcmp(buffer, "42   "));
-
-  test::sprintf(buffer, "%-5d", -42);
-  REQUIRE(!strcmp(buffer, "-42  "));
-
-  test::sprintf(buffer, "%-15d", 42);
-  REQUIRE(!strcmp(buffer, "42             "));
-
-  test::sprintf(buffer, "%-15d", -42);
-  REQUIRE(!strcmp(buffer, "-42            "));
-
-  test::sprintf(buffer, "%-0d", 42);
-  REQUIRE(!strcmp(buffer, "42"));
-
-  test::sprintf(buffer, "%-0d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "%-05d", 42);
-  REQUIRE(!strcmp(buffer, "42   "));
-
-  test::sprintf(buffer, "%-05d", -42);
-  REQUIRE(!strcmp(buffer, "-42  "));
-
-  test::sprintf(buffer, "%-015d", 42);
-  REQUIRE(!strcmp(buffer, "42             "));
-
-  test::sprintf(buffer, "%-015d", -42);
-  REQUIRE(!strcmp(buffer, "-42            "));
-
-  test::sprintf(buffer, "%0-d", 42);
-  REQUIRE(!strcmp(buffer, "42"));
-
-  test::sprintf(buffer, "%0-d", -42);
-  REQUIRE(!strcmp(buffer, "-42"));
-
-  test::sprintf(buffer, "%0-5d", 42);
-  REQUIRE(!strcmp(buffer, "42   "));
-
-  test::sprintf(buffer, "%0-5d", -42);
-  REQUIRE(!strcmp(buffer, "-42  "));
-
-  test::sprintf(buffer, "%0-15d", 42);
-  REQUIRE(!strcmp(buffer, "42             "));
-
-  test::sprintf(buffer, "%0-15d", -42);
-  REQUIRE(!strcmp(buffer, "-42            "));
-
-  test::sprintf(buffer, "%0-15.3e", -42.);
+  TEST_SPRINTF("42",
+               "%-d", 42);
+  TEST_SPRINTF("-42",
+               "%-d", -42);
+  TEST_SPRINTF("42   ",
+               "%-5d", 42);
+  TEST_SPRINTF("-42  ",
+               "%-5d", -42);
+  TEST_SPRINTF("42             ",
+               "%-15d", 42);
+  TEST_SPRINTF("-42            ",
+               "%-15d", -42);
+  TEST_SPRINTF("42",
+               "%-0d", 42);
+  TEST_SPRINTF("-42",
+               "%-0d", -42);
+  TEST_SPRINTF("42   ",
+               "%-05d", 42);
+  TEST_SPRINTF("-42  ",
+               "%-05d", -42);
+  TEST_SPRINTF("42             ",
+               "%-015d", 42);
+  TEST_SPRINTF("-42            ",
+               "%-015d", -42);
+  TEST_SPRINTF("42",
+               "%0-d", 42);
+  TEST_SPRINTF("-42",
+               "%0-d", -42);
+  TEST_SPRINTF("42   ",
+               "%0-5d", 42);
+  TEST_SPRINTF("-42  ",
+               "%0-5d", -42);
+  TEST_SPRINTF("42             ",
+               "%0-15d", 42);
+  TEST_SPRINTF("-42            ",
+               "%0-15d", -42);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  REQUIRE(!strcmp(buffer, "-4.200e+01     "));
+  TEST_SPRINTF("-4.200e+01     ",
+               "%0-15.3e", -42.);
 #else
-  REQUIRE(!strcmp(buffer, "e"));
+  TEST_SPRINTF("-4.200e+01     ",
+               "e", -42.);
 #endif
 
-  test::sprintf(buffer, "%0-15.3g", -42.);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  REQUIRE(!strcmp(buffer, "-42.0          "));
+  TEST_SPRINTF("-42.0          ",
+               "%0-15.3g", -42.);
 #else
-  REQUIRE(!strcmp(buffer, "g"));
+  TEST_SPRINTF("g",
+               "%0-15.3g", -42.);
 #endif
 }
 
 
 TEST_CASE("# flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%#.0x", 0);
-  REQUIRE(!strcmp(buffer, ""));
-  test::sprintf(buffer, "%#.1x", 0);
-  REQUIRE(!strcmp(buffer, "0"));
-  test::sprintf(buffer, "%#.0llx", (long long)0);
-  REQUIRE(!strcmp(buffer, ""));
-  test::sprintf(buffer, "%#.8x", 0x614e);
-  REQUIRE(!strcmp(buffer, "0x0000614e"));
-  test::sprintf(buffer,"%#b", 6);
-  REQUIRE(!strcmp(buffer, "0b110"));
+  TEST_SPRINTF("",
+               "%#.0x", 0);
+  TEST_SPRINTF("0",
+               "%#.1x", 0);
+  TEST_SPRINTF("",
+               "%#.0llx", (long long)0);
+  TEST_SPRINTF("0x0000614e",
+               "%#.8x", 0x614e);
+  TEST_SPRINTF("0b110",
+               "%#b", 6);
 }
 
 
 TEST_CASE("specifier", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "Hello testing");
-  REQUIRE(!strcmp(buffer, "Hello testing"));
-
-  test::sprintf(buffer, "%s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "Hello testing"));
-
-  test::sprintf(buffer, "%d", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%i", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%u", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272"));
-
-  test::sprintf(buffer, "%o", 511);
-  REQUIRE(!strcmp(buffer, "777"));
-
-  test::sprintf(buffer, "%o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001"));
-
-  test::sprintf(buffer, "%x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd"));
-
-  test::sprintf(buffer, "%x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433"));
-
-  test::sprintf(buffer, "%X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD"));
-
-  test::sprintf(buffer, "%X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433"));
-
-  test::sprintf(buffer, "%%");
-  REQUIRE(!strcmp(buffer, "%"));
+  TEST_SPRINTF("Hello testing",
+               "Hello testing");
+  TEST_SPRINTF("Hello testing",
+               "%s", "Hello testing");
+  TEST_SPRINTF("1024",
+               "%d", 1024);
+  TEST_SPRINTF("-1024",
+               "%d", -1024);
+  TEST_SPRINTF("1024",
+               "%i", 1024);
+  TEST_SPRINTF("-1024",
+               "%i", -1024);
+  TEST_SPRINTF("1024",
+               "%u", 1024);
+  TEST_SPRINTF("4294966272",
+               "%u", 4294966272U);
+  TEST_SPRINTF("777",
+               "%o", 511);
+  TEST_SPRINTF("37777777001",
+               "%o", 4294966785U);
+  TEST_SPRINTF("1234abcd",
+               "%x", 305441741);
+  TEST_SPRINTF("edcb5433",
+               "%x", 3989525555U);
+  TEST_SPRINTF("1234ABCD",
+               "%X", 305441741);
+  TEST_SPRINTF("EDCB5433",
+               "%X", 3989525555U);
+  TEST_SPRINTF("%",
+               "%%");
 }
 
 
 TEST_CASE("width", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%1s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "Hello testing"));
-
-  test::sprintf(buffer, "%1d", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%1d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%1i", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%1i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024"));
-
-  test::sprintf(buffer, "%1u", 1024);
-  REQUIRE(!strcmp(buffer, "1024"));
-
-  test::sprintf(buffer, "%1u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272"));
-
-  test::sprintf(buffer, "%1o", 511);
-  REQUIRE(!strcmp(buffer, "777"));
-
-  test::sprintf(buffer, "%1o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001"));
-
-  test::sprintf(buffer, "%1x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd"));
-
-  test::sprintf(buffer, "%1x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433"));
-
-  test::sprintf(buffer, "%1X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD"));
-
-  test::sprintf(buffer, "%1X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433"));
-
-  test::sprintf(buffer, "%1c", 'x');
-  REQUIRE(!strcmp(buffer, "x"));
+  TEST_SPRINTF("Hello testing",
+               "%1s", "Hello testing");
+  TEST_SPRINTF("1024",
+               "%1d", 1024);
+  TEST_SPRINTF("-1024",
+               "%1d", -1024);
+  TEST_SPRINTF("1024",
+               "%1i", 1024);
+  TEST_SPRINTF("-1024",
+               "%1i", -1024);
+  TEST_SPRINTF("1024",
+               "%1u", 1024);
+  TEST_SPRINTF("4294966272",
+               "%1u", 4294966272U);
+  TEST_SPRINTF("777",
+               "%1o", 511);
+  TEST_SPRINTF("37777777001",
+               "%1o", 4294966785U);
+  TEST_SPRINTF("1234abcd",
+               "%1x", 305441741);
+  TEST_SPRINTF("edcb5433",
+               "%1x", 3989525555U);
+  TEST_SPRINTF("1234ABCD",
+               "%1X", 305441741);
+  TEST_SPRINTF("EDCB5433",
+               "%1X", 3989525555U);
+  TEST_SPRINTF("x",
+               "%1c", 'x');
 }
 
 
 TEST_CASE("width 20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%20s", "Hello");
-  REQUIRE(!strcmp(buffer, "               Hello"));
-
-  test::sprintf(buffer, "%20d", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20d", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%20i", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20i", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%20u", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "          4294966272"));
-
-  test::sprintf(buffer, "%20o", 511);
-  REQUIRE(!strcmp(buffer, "                 777"));
-
-  test::sprintf(buffer, "%20o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "         37777777001"));
-
-  test::sprintf(buffer, "%20x", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234abcd"));
-
-  test::sprintf(buffer, "%20x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "            edcb5433"));
-
-  test::sprintf(buffer, "%20X", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234ABCD"));
-
-  test::sprintf(buffer, "%20X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "            EDCB5433"));
-
-  test::sprintf(buffer, "%20c", 'x');
-  REQUIRE(!strcmp(buffer, "                   x"));
+  TEST_SPRINTF("               Hello",
+               "%20s", "Hello");
+  TEST_SPRINTF("                1024",
+               "%20d", 1024);
+  TEST_SPRINTF("               -1024",
+               "%20d", -1024);
+  TEST_SPRINTF("                1024",
+               "%20i", 1024);
+  TEST_SPRINTF("               -1024",
+               "%20i", -1024);
+  TEST_SPRINTF("                1024",
+               "%20u", 1024);
+  TEST_SPRINTF("          4294966272",
+               "%20u", 4294966272U);
+  TEST_SPRINTF("                 777",
+               "%20o", 511);
+  TEST_SPRINTF("         37777777001",
+               "%20o", 4294966785U);
+  TEST_SPRINTF("            1234abcd",
+               "%20x", 305441741);
+  TEST_SPRINTF("            edcb5433",
+               "%20x", 3989525555U);
+  TEST_SPRINTF("            1234ABCD",
+               "%20X", 305441741);
+  TEST_SPRINTF("            EDCB5433",
+               "%20X", 3989525555U);
+  TEST_SPRINTF("                   x",
+               "%20c", 'x');
 }
 
 
 TEST_CASE("width *20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%*s", 20, "Hello");
-  REQUIRE(!strcmp(buffer, "               Hello"));
-
-  test::sprintf(buffer, "%*d", 20, 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%*d", 20, -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%*i", 20, 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%*i", 20, -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%*u", 20, 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%*u", 20, 4294966272U);
-  REQUIRE(!strcmp(buffer, "          4294966272"));
-
-  test::sprintf(buffer, "%*o", 20, 511);
-  REQUIRE(!strcmp(buffer, "                 777"));
-
-  test::sprintf(buffer, "%*o", 20, 4294966785U);
-  REQUIRE(!strcmp(buffer, "         37777777001"));
-
-  test::sprintf(buffer, "%*x", 20, 305441741);
-  REQUIRE(!strcmp(buffer, "            1234abcd"));
-
-  test::sprintf(buffer, "%*x", 20, 3989525555U);
-  REQUIRE(!strcmp(buffer, "            edcb5433"));
-
-  test::sprintf(buffer, "%*X", 20, 305441741);
-  REQUIRE(!strcmp(buffer, "            1234ABCD"));
-
-  test::sprintf(buffer, "%*X", 20, 3989525555U);
-  REQUIRE(!strcmp(buffer, "            EDCB5433"));
-
-  test::sprintf(buffer, "%*c", 20,'x');
-  REQUIRE(!strcmp(buffer, "                   x"));
+  TEST_SPRINTF("               Hello",
+               "%*s", 20, "Hello");
+  TEST_SPRINTF("                1024",
+               "%*d", 20, 1024);
+  TEST_SPRINTF("               -1024",
+               "%*d", 20, -1024);
+  TEST_SPRINTF("                1024",
+               "%*i", 20, 1024);
+  TEST_SPRINTF("               -1024",
+               "%*i", 20, -1024);
+  TEST_SPRINTF("                1024",
+               "%*u", 20, 1024);
+  TEST_SPRINTF("          4294966272",
+               "%*u", 20, 4294966272U);
+  TEST_SPRINTF("                 777",
+               "%*o", 20, 511);
+  TEST_SPRINTF("         37777777001",
+               "%*o", 20, 4294966785U);
+  TEST_SPRINTF("            1234abcd",
+               "%*x", 20, 305441741);
+  TEST_SPRINTF("            edcb5433",
+               "%*x", 20, 3989525555U);
+  TEST_SPRINTF("            1234ABCD",
+               "%*X", 20, 305441741);
+  TEST_SPRINTF("            EDCB5433",
+               "%*X", 20, 3989525555U);
+  TEST_SPRINTF("                   x",
+               "%*c", 20,'x');
 }
 
 
 TEST_CASE("width -20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%-20s", "Hello");
-  REQUIRE(!strcmp(buffer, "Hello               "));
-
-  test::sprintf(buffer, "%-20d", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%-20d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024               "));
-
-  test::sprintf(buffer, "%-20i", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%-20i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024               "));
-
-  test::sprintf(buffer, "%-20u", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%-20.4f", 1024.1234);
-  REQUIRE(!strcmp(buffer, "1024.1234           "));
-
-  test::sprintf(buffer, "%-20u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272          "));
-
-  test::sprintf(buffer, "%-20o", 511);
-  REQUIRE(!strcmp(buffer, "777                 "));
-
-  test::sprintf(buffer, "%-20o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001         "));
-
-  test::sprintf(buffer, "%-20x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd            "));
-
-  test::sprintf(buffer, "%-20x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433            "));
-
-  test::sprintf(buffer, "%-20X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD            "));
-
-  test::sprintf(buffer, "%-20X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433            "));
-
-  test::sprintf(buffer, "%-20c", 'x');
-  REQUIRE(!strcmp(buffer, "x                   "));
-
-  test::sprintf(buffer, "|%5d| |%-2d| |%5d|", 9, 9, 9);
-  REQUIRE(!strcmp(buffer, "|    9| |9 | |    9|"));
-
-  test::sprintf(buffer, "|%5d| |%-2d| |%5d|", 10, 10, 10);
-  REQUIRE(!strcmp(buffer, "|   10| |10| |   10|"));
-
-  test::sprintf(buffer, "|%5d| |%-12d| |%5d|", 9, 9, 9);
-  REQUIRE(!strcmp(buffer, "|    9| |9           | |    9|"));
-
-  test::sprintf(buffer, "|%5d| |%-12d| |%5d|", 10, 10, 10);
-  REQUIRE(!strcmp(buffer, "|   10| |10          | |   10|"));
+  TEST_SPRINTF("Hello               ",
+               "%-20s", "Hello");
+  TEST_SPRINTF("1024                ",
+               "%-20d", 1024);
+  TEST_SPRINTF("-1024               ",
+               "%-20d", -1024);
+  TEST_SPRINTF("1024                ",
+               "%-20i", 1024);
+  TEST_SPRINTF("-1024               ",
+               "%-20i", -1024);
+  TEST_SPRINTF("1024                ",
+               "%-20u", 1024);
+  TEST_SPRINTF("1024.1234           ",
+               "%-20.4f", 1024.1234);
+  TEST_SPRINTF("4294966272          ",
+               "%-20u", 4294966272U);
+  TEST_SPRINTF("777                 ",
+               "%-20o", 511);
+  TEST_SPRINTF("37777777001         ",
+               "%-20o", 4294966785U);
+  TEST_SPRINTF("1234abcd            ",
+               "%-20x", 305441741);
+  TEST_SPRINTF("edcb5433            ",
+               "%-20x", 3989525555U);
+  TEST_SPRINTF("1234ABCD            ",
+               "%-20X", 305441741);
+  TEST_SPRINTF("EDCB5433            ",
+               "%-20X", 3989525555U);
+  TEST_SPRINTF("x                   ",
+               "%-20c", 'x');
+  TEST_SPRINTF("|    9| |9 | |    9|",
+               "|%5d| |%-2d| |%5d|", 9, 9, 9);
+  TEST_SPRINTF("|   10| |10| |   10|",
+               "|%5d| |%-2d| |%5d|", 10, 10, 10);
+  TEST_SPRINTF("|    9| |9           | |    9|",
+               "|%5d| |%-12d| |%5d|", 9, 9, 9);
+  TEST_SPRINTF("|   10| |10          | |   10|",
+               "|%5d| |%-12d| |%5d|", 10, 10, 10);
 }
 
 
 TEST_CASE("width 0-20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%0-20s", "Hello");
-  REQUIRE(!strcmp(buffer, "Hello               "));
-
-  test::sprintf(buffer, "%0-20d", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%0-20d", -1024);
-  REQUIRE(!strcmp(buffer, "-1024               "));
-
-  test::sprintf(buffer, "%0-20i", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%0-20i", -1024);
-  REQUIRE(!strcmp(buffer, "-1024               "));
-
-  test::sprintf(buffer, "%0-20u", 1024);
-  REQUIRE(!strcmp(buffer, "1024                "));
-
-  test::sprintf(buffer, "%0-20u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "4294966272          "));
-
-  test::sprintf(buffer, "%0-20o", 511);
-  REQUIRE(!strcmp(buffer, "777                 "));
-
-  test::sprintf(buffer, "%0-20o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "37777777001         "));
-
-  test::sprintf(buffer, "%0-20x", 305441741);
-  REQUIRE(!strcmp(buffer, "1234abcd            "));
-
-  test::sprintf(buffer, "%0-20x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "edcb5433            "));
-
-  test::sprintf(buffer, "%0-20X", 305441741);
-  REQUIRE(!strcmp(buffer, "1234ABCD            "));
-
-  test::sprintf(buffer, "%0-20X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "EDCB5433            "));
-
-  test::sprintf(buffer, "%0-20c", 'x');
-  REQUIRE(!strcmp(buffer, "x                   "));
+  TEST_SPRINTF("Hello               ",
+               "%0-20s", "Hello");
+  TEST_SPRINTF("1024                ",
+               "%0-20d", 1024);
+  TEST_SPRINTF("-1024               ",
+               "%0-20d", -1024);
+  TEST_SPRINTF("1024                ",
+               "%0-20i", 1024);
+  TEST_SPRINTF("-1024               ",
+               "%0-20i", -1024);
+  TEST_SPRINTF("1024                ",
+               "%0-20u", 1024);
+  TEST_SPRINTF("4294966272          ",
+               "%0-20u", 4294966272U);
+  TEST_SPRINTF("777                 ",
+               "%0-20o", 511);
+  TEST_SPRINTF("37777777001         ",
+               "%0-20o", 4294966785U);
+  TEST_SPRINTF("1234abcd            ",
+               "%0-20x", 305441741);
+  TEST_SPRINTF("edcb5433            ",
+               "%0-20x", 3989525555U);
+  TEST_SPRINTF("1234ABCD            ",
+               "%0-20X", 305441741);
+  TEST_SPRINTF("EDCB5433            ",
+               "%0-20X", 3989525555U);
+  TEST_SPRINTF("x                   ",
+               "%0-20c", 'x');
 }
 
 
 TEST_CASE("padding 20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%020d", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%020d", -1024);
-  REQUIRE(!strcmp(buffer, "-0000000000000001024"));
-
-  test::sprintf(buffer, "%020i", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%020i", -1024);
-  REQUIRE(!strcmp(buffer, "-0000000000000001024"));
-
-  test::sprintf(buffer, "%020u", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%020u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "00000000004294966272"));
-
-  test::sprintf(buffer, "%020o", 511);
-  REQUIRE(!strcmp(buffer, "00000000000000000777"));
-
-  test::sprintf(buffer, "%020o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "00000000037777777001"));
-
-  test::sprintf(buffer, "%020x", 305441741);
-  REQUIRE(!strcmp(buffer, "0000000000001234abcd"));
-
-  test::sprintf(buffer, "%020x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "000000000000edcb5433"));
-
-  test::sprintf(buffer, "%020X", 305441741);
-  REQUIRE(!strcmp(buffer, "0000000000001234ABCD"));
-
-  test::sprintf(buffer, "%020X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "000000000000EDCB5433"));
+  TEST_SPRINTF("00000000000000001024",
+               "%020d", 1024);
+  TEST_SPRINTF("-0000000000000001024",
+               "%020d", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%020i", 1024);
+  TEST_SPRINTF("-0000000000000001024",
+               "%020i", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%020u", 1024);
+  TEST_SPRINTF("00000000004294966272",
+               "%020u", 4294966272U);
+  TEST_SPRINTF("00000000000000000777",
+               "%020o", 511);
+  TEST_SPRINTF("00000000037777777001",
+               "%020o", 4294966785U);
+  TEST_SPRINTF("0000000000001234abcd",
+               "%020x", 305441741);
+  TEST_SPRINTF("000000000000edcb5433",
+               "%020x", 3989525555U);
+  TEST_SPRINTF("0000000000001234ABCD",
+               "%020X", 305441741);
+  TEST_SPRINTF("000000000000EDCB5433",
+               "%020X", 3989525555U);
 }
 
 
 TEST_CASE("padding .20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%.20d", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%.20d", -1024);
-  REQUIRE(!strcmp(buffer, "-00000000000000001024"));
-
-  test::sprintf(buffer, "%.20i", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%.20i", -1024);
-  REQUIRE(!strcmp(buffer, "-00000000000000001024"));
-
-  test::sprintf(buffer, "%.20u", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%.20u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "00000000004294966272"));
-
-  test::sprintf(buffer, "%.20o", 511);
-  REQUIRE(!strcmp(buffer, "00000000000000000777"));
-
-  test::sprintf(buffer, "%.20o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "00000000037777777001"));
-
-  test::sprintf(buffer, "%.20x", 305441741);
-  REQUIRE(!strcmp(buffer, "0000000000001234abcd"));
-
-  test::sprintf(buffer, "%.20x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "000000000000edcb5433"));
-
-  test::sprintf(buffer, "%.20X", 305441741);
-  REQUIRE(!strcmp(buffer, "0000000000001234ABCD"));
-
-  test::sprintf(buffer, "%.20X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "000000000000EDCB5433"));
+  TEST_SPRINTF("00000000000000001024",
+               "%.20d", 1024);
+  TEST_SPRINTF("-00000000000000001024",
+               "%.20d", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%.20i", 1024);
+  TEST_SPRINTF("-00000000000000001024",
+               "%.20i", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%.20u", 1024);
+  TEST_SPRINTF("00000000004294966272",
+               "%.20u", 4294966272U);
+  TEST_SPRINTF("00000000000000000777",
+               "%.20o", 511);
+  TEST_SPRINTF("00000000037777777001",
+               "%.20o", 4294966785U);
+  TEST_SPRINTF("0000000000001234abcd",
+               "%.20x", 305441741);
+  TEST_SPRINTF("000000000000edcb5433",
+               "%.20x", 3989525555U);
+  TEST_SPRINTF("0000000000001234ABCD",
+               "%.20X", 305441741);
+  TEST_SPRINTF("000000000000EDCB5433",
+               "%.20X", 3989525555U);
 }
 
 
 TEST_CASE("padding #020", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%#020d", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%#020d", -1024);
-  REQUIRE(!strcmp(buffer, "-0000000000000001024"));
-
-  test::sprintf(buffer, "%#020i", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%#020i", -1024);
-  REQUIRE(!strcmp(buffer, "-0000000000000001024"));
-
-  test::sprintf(buffer, "%#020u", 1024);
-  REQUIRE(!strcmp(buffer, "00000000000000001024"));
-
-  test::sprintf(buffer, "%#020u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "00000000004294966272"));
-
-  test::sprintf(buffer, "%#020o", 511);
-  REQUIRE(!strcmp(buffer, "00000000000000000777"));
-
-  test::sprintf(buffer, "%#020o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "00000000037777777001"));
-
-  test::sprintf(buffer, "%#020x", 305441741);
-  REQUIRE(!strcmp(buffer, "0x00000000001234abcd"));
-
-  test::sprintf(buffer, "%#020x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "0x0000000000edcb5433"));
-
-  test::sprintf(buffer, "%#020X", 305441741);
-  REQUIRE(!strcmp(buffer, "0X00000000001234ABCD"));
-
-  test::sprintf(buffer, "%#020X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "0X0000000000EDCB5433"));
+  TEST_SPRINTF("00000000000000001024",
+               "%#020d", 1024);
+  TEST_SPRINTF("-0000000000000001024",
+               "%#020d", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%#020i", 1024);
+  TEST_SPRINTF("-0000000000000001024",
+               "%#020i", -1024);
+  TEST_SPRINTF("00000000000000001024",
+               "%#020u", 1024);
+  TEST_SPRINTF("00000000004294966272",
+               "%#020u", 4294966272U);
+  TEST_SPRINTF("00000000000000000777",
+               "%#020o", 511);
+  TEST_SPRINTF("00000000037777777001",
+               "%#020o", 4294966785U);
+  TEST_SPRINTF("0x00000000001234abcd",
+               "%#020x", 305441741);
+  TEST_SPRINTF("0x0000000000edcb5433",
+               "%#020x", 3989525555U);
+  TEST_SPRINTF("0X00000000001234ABCD",
+               "%#020X", 305441741);
+  TEST_SPRINTF("0X0000000000EDCB5433",
+               "%#020X", 3989525555U);
 }
 
 
 TEST_CASE("padding #20", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%#20d", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%#20d", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%#20i", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%#20i", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%#20u", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%#20u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "          4294966272"));
-
-  test::sprintf(buffer, "%#20o", 511);
-  REQUIRE(!strcmp(buffer, "                0777"));
-
-  test::sprintf(buffer, "%#20o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "        037777777001"));
-
-  test::sprintf(buffer, "%#20x", 305441741);
-  REQUIRE(!strcmp(buffer, "          0x1234abcd"));
-
-  test::sprintf(buffer, "%#20x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "          0xedcb5433"));
-
-  test::sprintf(buffer, "%#20X", 305441741);
-  REQUIRE(!strcmp(buffer, "          0X1234ABCD"));
-
-  test::sprintf(buffer, "%#20X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "          0XEDCB5433"));
+  TEST_SPRINTF("                1024",
+               "%#20d", 1024);
+  TEST_SPRINTF("               -1024",
+               "%#20d", -1024);
+  TEST_SPRINTF("                1024",
+               "%#20i", 1024);
+  TEST_SPRINTF("               -1024",
+               "%#20i", -1024);
+  TEST_SPRINTF("                1024",
+               "%#20u", 1024);
+  TEST_SPRINTF("          4294966272",
+               "%#20u", 4294966272U);
+  TEST_SPRINTF("                0777",
+               "%#20o", 511);
+  TEST_SPRINTF("        037777777001",
+               "%#20o", 4294966785U);
+  TEST_SPRINTF("          0x1234abcd",
+               "%#20x", 305441741);
+  TEST_SPRINTF("          0xedcb5433",
+               "%#20x", 3989525555U);
+  TEST_SPRINTF("          0X1234ABCD",
+               "%#20X", 305441741);
+  TEST_SPRINTF("          0XEDCB5433",
+               "%#20X", 3989525555U);
 }
 
 
 TEST_CASE("padding 20.5", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%20.5d", 1024);
-  REQUIRE(!strcmp(buffer, "               01024"));
-
-  test::sprintf(buffer, "%20.5d", -1024);
-  REQUIRE(!strcmp(buffer, "              -01024"));
-
-  test::sprintf(buffer, "%20.5i", 1024);
-  REQUIRE(!strcmp(buffer, "               01024"));
-
-  test::sprintf(buffer, "%20.5i", -1024);
-  REQUIRE(!strcmp(buffer, "              -01024"));
-
-  test::sprintf(buffer, "%20.5u", 1024);
-  REQUIRE(!strcmp(buffer, "               01024"));
-
-  test::sprintf(buffer, "%20.5u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "          4294966272"));
-
-  test::sprintf(buffer, "%20.5o", 511);
-  REQUIRE(!strcmp(buffer, "               00777"));
-
-  test::sprintf(buffer, "%20.5o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "         37777777001"));
-
-  test::sprintf(buffer, "%20.5x", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234abcd"));
-
-  test::sprintf(buffer, "%20.10x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "          00edcb5433"));
-
-  test::sprintf(buffer, "%20.5X", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234ABCD"));
-
-  test::sprintf(buffer, "%20.10X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "          00EDCB5433"));
+  TEST_SPRINTF("               01024",
+               "%20.5d", 1024);
+  TEST_SPRINTF("              -01024",
+               "%20.5d", -1024);
+  TEST_SPRINTF("               01024",
+               "%20.5i", 1024);
+  TEST_SPRINTF("              -01024",
+               "%20.5i", -1024);
+  TEST_SPRINTF("               01024",
+               "%20.5u", 1024);
+  TEST_SPRINTF("          4294966272",
+               "%20.5u", 4294966272U);
+  TEST_SPRINTF("               00777",
+               "%20.5o", 511);
+  TEST_SPRINTF("         37777777001",
+               "%20.5o", 4294966785U);
+  TEST_SPRINTF("            1234abcd",
+               "%20.5x", 305441741);
+  TEST_SPRINTF("          00edcb5433",
+               "%20.10x", 3989525555U);
+  TEST_SPRINTF("            1234ABCD",
+               "%20.5X", 305441741);
+  TEST_SPRINTF("          00EDCB5433",
+               "%20.10X", 3989525555U);
 }
 
 
 TEST_CASE("padding neg numbers", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
   // space padding
-  test::sprintf(buffer, "% 1d", -5);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "% 2d", -5);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "% 3d", -5);
-  REQUIRE(!strcmp(buffer, " -5"));
-
-  test::sprintf(buffer, "% 4d", -5);
-  REQUIRE(!strcmp(buffer, "  -5"));
-
+  TEST_SPRINTF("-5",
+               "% 1d", -5);
+  TEST_SPRINTF("-5",
+               "% 2d", -5);
+  TEST_SPRINTF(" -5",
+               "% 3d", -5);
+  TEST_SPRINTF("  -5",
+               "% 4d", -5);
   // zero padding
-  test::sprintf(buffer, "%01d", -5);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "%02d", -5);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "%03d", -5);
-  REQUIRE(!strcmp(buffer, "-05"));
-
-  test::sprintf(buffer, "%04d", -5);
-  REQUIRE(!strcmp(buffer, "-005"));
+  TEST_SPRINTF("-5",
+               "%01d", -5);
+  TEST_SPRINTF("-5",
+               "%02d", -5);
+  TEST_SPRINTF("-05",
+               "%03d", -5);
+  TEST_SPRINTF("-005",
+               "%04d", -5);
 }
 
 
 TEST_CASE("float padding neg numbers", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
   // space padding
-  test::sprintf(buffer, "% 3.1f", -5.);
-  REQUIRE(!strcmp(buffer, "-5.0"));
-
-  test::sprintf(buffer, "% 4.1f", -5.);
-  REQUIRE(!strcmp(buffer, "-5.0"));
-
-  test::sprintf(buffer, "% 5.1f", -5.);
-  REQUIRE(!strcmp(buffer, " -5.0"));
-
+  TEST_SPRINTF("-5.0",
+               "% 3.1f", -5.);
+  TEST_SPRINTF("-5.0",
+               "% 4.1f", -5.);
+  TEST_SPRINTF(" -5.0",
+               "% 5.1f", -5.);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  test::sprintf(buffer, "% 6.1g", -5.);
-  REQUIRE(!strcmp(buffer, "    -5"));
-
-  test::sprintf(buffer, "% 6.1e", -5.);
-  REQUIRE(!strcmp(buffer, "-5.0e+00"));
-
-  test::sprintf(buffer, "% 10.1e", -5.);
-  REQUIRE(!strcmp(buffer, "  -5.0e+00"));
+  TEST_SPRINTF("    -5",
+               "% 6.1g", -5.);
+  TEST_SPRINTF("-5.0e+00",
+               "% 6.1e", -5.);
+  TEST_SPRINTF("  -5.0e+00",
+               "% 10.1e", -5.);
 #endif
 
   // zero padding
-  test::sprintf(buffer, "%03.1f", -5.);
-  REQUIRE(!strcmp(buffer, "-5.0"));
-
-  test::sprintf(buffer, "%04.1f", -5.);
-  REQUIRE(!strcmp(buffer, "-5.0"));
-
-  test::sprintf(buffer, "%05.1f", -5.);
-  REQUIRE(!strcmp(buffer, "-05.0"));
-
+  TEST_SPRINTF("-5.0",
+               "%03.1f", -5.);
+  TEST_SPRINTF("-5.0",
+               "%04.1f", -5.);
+  TEST_SPRINTF("-05.0",
+               "%05.1f", -5.);
   // zero padding no decimal point
-  test::sprintf(buffer, "%01.0f", -5.);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "%02.0f", -5.);
-  REQUIRE(!strcmp(buffer, "-5"));
-
-  test::sprintf(buffer, "%03.0f", -5.);
-  REQUIRE(!strcmp(buffer, "-05"));
-
+  TEST_SPRINTF("-5",
+               "%01.0f", -5.);
+  TEST_SPRINTF("-5",
+               "%02.0f", -5.);
+  TEST_SPRINTF("-05",
+               "%03.0f", -5.);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  test::sprintf(buffer, "%010.1e", -5.);
-  REQUIRE(!strcmp(buffer, "-005.0e+00"));
-
-  test::sprintf(buffer, "%07.0E", -5.);
-  REQUIRE(!strcmp(buffer, "-05E+00"));
-
-  test::sprintf(buffer, "%03.0g", -5.);
-  REQUIRE(!strcmp(buffer, "-05"));
+  TEST_SPRINTF("-005.0e+00",
+               "%010.1e", -5.);
+  TEST_SPRINTF("-05E+00",
+               "%07.0E", -5.);
+  TEST_SPRINTF("-05",
+               "%03.0g", -5.);
 #endif
 }
 
 TEST_CASE("length", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%.0s", "Hello testing");
-  REQUIRE(!strcmp(buffer, ""));
-
-  test::sprintf(buffer, "%20.0s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%.s", "Hello testing");
-  REQUIRE(!strcmp(buffer, ""));
-
-  test::sprintf(buffer, "%20.s", "Hello testing");
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.0d", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20.0d", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%20.d", 0);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.0i", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20.i", -1024);
-  REQUIRE(!strcmp(buffer, "               -1024"));
-
-  test::sprintf(buffer, "%20.i", 0);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.u", 1024);
-  REQUIRE(!strcmp(buffer, "                1024"));
-
-  test::sprintf(buffer, "%20.0u", 4294966272U);
-  REQUIRE(!strcmp(buffer, "          4294966272"));
-
-  test::sprintf(buffer, "%20.u", 0U);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.o", 511);
-  REQUIRE(!strcmp(buffer, "                 777"));
-
-  test::sprintf(buffer, "%20.0o", 4294966785U);
-  REQUIRE(!strcmp(buffer, "         37777777001"));
-
-  test::sprintf(buffer, "%20.o", 0U);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.x", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234abcd"));
-
-  test::sprintf(buffer, "%50.x", 305441741);
-  REQUIRE(!strcmp(buffer, "                                          1234abcd"));
-
-  test::sprintf(buffer, "%50.x%10.u", 305441741, 12345);
-  REQUIRE(!strcmp(buffer, "                                          1234abcd     12345"));
-
-  test::sprintf(buffer, "%20.0x", 3989525555U);
-  REQUIRE(!strcmp(buffer, "            edcb5433"));
-
-  test::sprintf(buffer, "%20.x", 0U);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%20.X", 305441741);
-  REQUIRE(!strcmp(buffer, "            1234ABCD"));
-
-  test::sprintf(buffer, "%20.0X", 3989525555U);
-  REQUIRE(!strcmp(buffer, "            EDCB5433"));
-
-  test::sprintf(buffer, "%20.X", 0U);
-  REQUIRE(!strcmp(buffer, "                    "));
-
-  test::sprintf(buffer, "%02.0u", 0U);
-  REQUIRE(!strcmp(buffer, "  "));
-
-  test::sprintf(buffer, "%02.0d", 0);
-  REQUIRE(!strcmp(buffer, "  "));
+  TEST_SPRINTF("",
+               "%.0s", "Hello testing");
+  TEST_SPRINTF("                    ",
+               "%20.0s", "Hello testing");
+  TEST_SPRINTF("",
+               "%.s", "Hello testing");
+  TEST_SPRINTF("                    ",
+               "%20.s", "Hello testing");
+  TEST_SPRINTF("                1024",
+               "%20.0d", 1024);
+  TEST_SPRINTF("               -1024",
+               "%20.0d", -1024);
+  TEST_SPRINTF("                    ",
+               "%20.d", 0);
+  TEST_SPRINTF("                1024",
+               "%20.0i", 1024);
+  TEST_SPRINTF("               -1024",
+               "%20.i", -1024);
+  TEST_SPRINTF("                    ",
+               "%20.i", 0);
+  TEST_SPRINTF("                1024",
+               "%20.u", 1024);
+  TEST_SPRINTF("          4294966272",
+               "%20.0u", 4294966272U);
+  TEST_SPRINTF("                    ",
+               "%20.u", 0U);
+  TEST_SPRINTF("                 777",
+               "%20.o", 511);
+  TEST_SPRINTF("         37777777001",
+               "%20.0o", 4294966785U);
+  TEST_SPRINTF("                    ",
+               "%20.o", 0U);
+  TEST_SPRINTF("            1234abcd",
+               "%20.x", 305441741);
+  TEST_SPRINTF("                                          1234abcd",
+               "%50.x", 305441741);
+  TEST_SPRINTF("                                          1234abcd     12345",
+               "%50.x%10.u", 305441741, 12345);
+  TEST_SPRINTF("            edcb5433",
+               "%20.0x", 3989525555U);
+  TEST_SPRINTF("                    ",
+               "%20.x", 0U);
+  TEST_SPRINTF("            1234ABCD",
+               "%20.X", 305441741);
+  TEST_SPRINTF("            EDCB5433",
+               "%20.0X", 3989525555U);
+  TEST_SPRINTF("                    ",
+               "%20.X", 0U);
+  TEST_SPRINTF("  ",
+               "%02.0u", 0U);
+  TEST_SPRINTF("  ",
+               "%02.0d", 0);
 }
 
 
 TEST_CASE("float", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
   // test special-case floats using math.h macros
-  test::sprintf(buffer, "%8f", NAN);
-  REQUIRE(!strcmp(buffer, "     nan"));
-
-  test::sprintf(buffer, "%8f", INFINITY);
-  REQUIRE(!strcmp(buffer, "     inf"));
-
-  test::sprintf(buffer, "%-8f", -INFINITY);
-  REQUIRE(!strcmp(buffer, "-inf    "));
-
+  TEST_SPRINTF("     nan",
+               "%8f", NAN);
+  TEST_SPRINTF("     inf",
+               "%8f", (double)INFINITY);
+  TEST_SPRINTF("-inf    ",
+               "%-8f", (double)-INFINITY);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  test::sprintf(buffer, "%+8e", INFINITY);
-  REQUIRE(!strcmp(buffer, "    +inf"));
+  TEST_SPRINTF("    +inf",
+               "%+8e", (double)INFINITY);
 #endif
 
-  test::sprintf(buffer, "%.4f", 3.1415354);
-  REQUIRE(!strcmp(buffer, "3.1415"));
-
-  test::sprintf(buffer, "%.3f", 30343.1415354);
-  REQUIRE(!strcmp(buffer, "30343.142"));
-
-  test::sprintf(buffer, "%.0f", 34.1415354);
-  REQUIRE(!strcmp(buffer, "34"));
-
-  test::sprintf(buffer, "%.0f", 1.3);
-  REQUIRE(!strcmp(buffer, "1"));
-
-  test::sprintf(buffer, "%.0f", 1.55);
-  REQUIRE(!strcmp(buffer, "2"));
-
-  test::sprintf(buffer, "%.1f", 1.64);
-  REQUIRE(!strcmp(buffer, "1.6"));
-
-  test::sprintf(buffer, "%.2f", 42.8952);
-  REQUIRE(!strcmp(buffer, "42.90"));
-
-  test::sprintf(buffer, "%.9f", 42.8952);
-  REQUIRE(!strcmp(buffer, "42.895200000"));
-
-  test::sprintf(buffer, "%.10f", 42.895223);
-  REQUIRE(!strcmp(buffer, "42.8952230000"));
-
+  TEST_SPRINTF("3.1415",
+               "%.4f", 3.1415354);
+  TEST_SPRINTF("30343.142",
+               "%.3f", 30343.1415354);
+  TEST_SPRINTF("34",
+               "%.0f", 34.1415354);
+  TEST_SPRINTF("1",
+               "%.0f", 1.3);
+  TEST_SPRINTF("2",
+               "%.0f", 1.55);
+  TEST_SPRINTF("1.6",
+               "%.1f", 1.64);
+  TEST_SPRINTF("42.90",
+               "%.2f", 42.8952);
+  TEST_SPRINTF("42.895200000",
+               "%.9f", 42.8952);
+  TEST_SPRINTF("42.8952230000",
+               "%.10f", 42.895223);
   // this testcase checks, that the precision is truncated to 9 digits.
   // a perfect working float should return the whole number
-  test::sprintf(buffer, "%.12f", 42.89522312345678);
-  REQUIRE(!strcmp(buffer, "42.895223123000"));
-
+  TEST_SPRINTF("42.895223123000",
+               "%.12f", 42.89522312345678);
   // this testcase checks, that the precision is truncated AND rounded to 9 digits.
   // a perfect working float should return the whole number
-  test::sprintf(buffer, "%.12f", 42.89522387654321);
-  REQUIRE(!strcmp(buffer, "42.895223877000"));
-
-  test::sprintf(buffer, "%6.2f", 42.8952);
-  REQUIRE(!strcmp(buffer, " 42.90"));
-
-  test::sprintf(buffer, "%+6.2f", 42.8952);
-  REQUIRE(!strcmp(buffer, "+42.90"));
-
-  test::sprintf(buffer, "%+5.1f", 42.9252);
-  REQUIRE(!strcmp(buffer, "+42.9"));
-
-  test::sprintf(buffer, "%f", 42.5);
-  REQUIRE(!strcmp(buffer, "42.500000"));
-
-  test::sprintf(buffer, "%.1f", 42.5);
-  REQUIRE(!strcmp(buffer, "42.5"));
-
-  test::sprintf(buffer, "%f", 42167.0);
-  REQUIRE(!strcmp(buffer, "42167.000000"));
-
-  test::sprintf(buffer, "%.9f", -12345.987654321);
-  REQUIRE(!strcmp(buffer, "-12345.987654321"));
-
-  test::sprintf(buffer, "%.1f", 3.999);
-  REQUIRE(!strcmp(buffer, "4.0"));
-
-  test::sprintf(buffer, "%.0f", 3.5);
-  REQUIRE(!strcmp(buffer, "4"));
-
-  test::sprintf(buffer, "%.0f", 4.5);
-  REQUIRE(!strcmp(buffer, "4"));
-
-  test::sprintf(buffer, "%.0f", 3.49);
-  REQUIRE(!strcmp(buffer, "3"));
-
-  test::sprintf(buffer, "%.1f", 3.49);
-  REQUIRE(!strcmp(buffer, "3.5"));
-
-  test::sprintf(buffer, "a%-5.1f", 0.5);
-  REQUIRE(!strcmp(buffer, "a0.5  "));
-
-  test::sprintf(buffer, "a%-5.1fend", 0.5);
-  REQUIRE(!strcmp(buffer, "a0.5  end"));
-
+  TEST_SPRINTF("42.895223877000",
+               "%.12f", 42.89522387654321);
+  TEST_SPRINTF(" 42.90",
+               "%6.2f", 42.8952);
+  TEST_SPRINTF("+42.90",
+               "%+6.2f", 42.8952);
+  TEST_SPRINTF("+42.9",
+               "%+5.1f", 42.9252);
+  TEST_SPRINTF("42.500000",
+               "%f", 42.5);
+  TEST_SPRINTF("42.5",
+               "%.1f", 42.5);
+  TEST_SPRINTF("42167.000000",
+               "%f", 42167.0);
+  TEST_SPRINTF("-12345.987654321",
+               "%.9f", -12345.987654321);
+  TEST_SPRINTF("4.0",
+               "%.1f", 3.999);
+  TEST_SPRINTF("4",
+               "%.0f", 3.5);
+  TEST_SPRINTF("4",
+               "%.0f", 4.5);
+  TEST_SPRINTF("3",
+               "%.0f", 3.49);
+  TEST_SPRINTF("3.5",
+               "%.1f", 3.49);
+  TEST_SPRINTF("a0.5  ",
+               "a%-5.1f", 0.5);
+  TEST_SPRINTF("a0.5  end",
+               "a%-5.1fend", 0.5);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  test::sprintf(buffer, "%G", 12345.678);
-  REQUIRE(!strcmp(buffer, "12345.7"));
-
-  test::sprintf(buffer, "%.7G", 12345.678);
-  REQUIRE(!strcmp(buffer, "12345.68"));
-
-  test::sprintf(buffer, "%.5G", 123456789.);
-  REQUIRE(!strcmp(buffer, "1.2346E+08"));
-
-  test::sprintf(buffer, "%.6G", 12345.);
-  REQUIRE(!strcmp(buffer, "12345.0"));
-
-  test::sprintf(buffer, "%+12.4g", 123456789.);
-  REQUIRE(!strcmp(buffer, "  +1.235e+08"));
-
-  test::sprintf(buffer, "%.2G", 0.001234);
-  REQUIRE(!strcmp(buffer, "0.0012"));
-
-  test::sprintf(buffer, "%+10.4G", 0.001234);
-  REQUIRE(!strcmp(buffer, " +0.001234"));
-
-  test::sprintf(buffer, "%+012.4g", 0.00001234);
-  REQUIRE(!strcmp(buffer, "+001.234e-05"));
-
-  test::sprintf(buffer, "%.3g", -1.2345e-308);
-  REQUIRE(!strcmp(buffer, "-1.23e-308"));
-
-  test::sprintf(buffer, "%+.3E", 1.23e+308);
-  REQUIRE(!strcmp(buffer, "+1.230E+308"));
+  TEST_SPRINTF("12345.7",
+               "%G", 12345.678);
+  TEST_SPRINTF("12345.68",
+               "%.7G", 12345.678);
+  TEST_SPRINTF("1.2346E+08",
+               "%.5G", 123456789.);
+  TEST_SPRINTF("12345.0",
+               "%.6G", 12345.);
+  TEST_SPRINTF("  +1.235e+08",
+               "%+12.4g", 123456789.);
+  TEST_SPRINTF("0.0012",
+               "%.2G", 0.001234);
+  TEST_SPRINTF(" +0.001234",
+               "%+10.4G", 0.001234);
+  TEST_SPRINTF("+001.234e-05",
+               "%+012.4g", 0.00001234);
+  TEST_SPRINTF("-1.23e-308",
+               "%.3g", -1.2345e-308);
+  TEST_SPRINTF("+1.230E+308",
+               "%+.3E", 1.23e+308);
 #endif
 
   // out of range for float: should switch to exp notation if supported, else empty
-  test::sprintf(buffer, "%.1f", 1E20);
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  REQUIRE(!strcmp(buffer, "1.0e+20"));
+  TEST_SPRINTF("1.0e+20",
+               "%.1f", 1E20);
 #else
-  REQUIRE(!strcmp(buffer, ""));
+  TEST_SPRINTF("",
+               "%.1f", 1E20);
 #endif
 
   // brute force float
@@ -1217,7 +969,7 @@ TEST_CASE("float", "[]" ) {
   std::stringstream str;
   str.precision(5);
   for (float i = -100000; i < 100000; i += 1) {
-    test::sprintf(buffer, "%.5f", i / 10000);
+    tested_sprintf(buffer, "%.5f", (double)i / 10000);
     str.str("");
     str << std::fixed << i / 10000;
     fail = fail || !!strcmp(buffer, str.str().c_str());
@@ -1228,8 +980,8 @@ TEST_CASE("float", "[]" ) {
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
   // brute force exp
   str.setf(std::ios::scientific, std::ios::floatfield);
-  for (float i = -1e20; i < 1e20; i += 1e15) {
-    test::sprintf(buffer, "%.5f", i);
+  for (float i = -1e20; i < 1e20f; i += 1e15f) {
+    tested_sprintf(buffer, "%.5f", (double)i);
     str.str("");
     str << i;
     fail = fail || !!strcmp(buffer, str.str().c_str());
@@ -1240,274 +992,222 @@ TEST_CASE("float", "[]" ) {
 
 
 TEST_CASE("types", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%i", 0);
-  REQUIRE(!strcmp(buffer, "0"));
-
-  test::sprintf(buffer, "%i", 1234);
-  REQUIRE(!strcmp(buffer, "1234"));
-
-  test::sprintf(buffer, "%i", 32767);
-  REQUIRE(!strcmp(buffer, "32767"));
-
-  test::sprintf(buffer, "%i", -32767);
-  REQUIRE(!strcmp(buffer, "-32767"));
-
-  test::sprintf(buffer, "%li", 30L);
-  REQUIRE(!strcmp(buffer, "30"));
-
-  test::sprintf(buffer, "%li", -2147483647L);
-  REQUIRE(!strcmp(buffer, "-2147483647"));
-
-  test::sprintf(buffer, "%li", 2147483647L);
-  REQUIRE(!strcmp(buffer, "2147483647"));
-
-  test::sprintf(buffer, "%lli", 30LL);
-  REQUIRE(!strcmp(buffer, "30"));
-
-  test::sprintf(buffer, "%lli", -9223372036854775807LL);
-  REQUIRE(!strcmp(buffer, "-9223372036854775807"));
-
-  test::sprintf(buffer, "%lli", 9223372036854775807LL);
-  REQUIRE(!strcmp(buffer, "9223372036854775807"));
-
-  test::sprintf(buffer, "%lu", 100000L);
-  REQUIRE(!strcmp(buffer, "100000"));
-
-  test::sprintf(buffer, "%lu", 0xFFFFFFFFL);
-  REQUIRE(!strcmp(buffer, "4294967295"));
-
-  test::sprintf(buffer, "%llu", 281474976710656LLU);
-  REQUIRE(!strcmp(buffer, "281474976710656"));
-
-  test::sprintf(buffer, "%llu", 18446744073709551615LLU);
-  REQUIRE(!strcmp(buffer, "18446744073709551615"));
-
-  test::sprintf(buffer, "%zu", 2147483647UL);
-  REQUIRE(!strcmp(buffer, "2147483647"));
-
-  test::sprintf(buffer, "%zd", 2147483647UL);
-  REQUIRE(!strcmp(buffer, "2147483647"));
-
+  TEST_SPRINTF("0",
+               "%i", 0);
+  TEST_SPRINTF("1234",
+               "%i", 1234);
+  TEST_SPRINTF("32767",
+               "%i", 32767);
+  TEST_SPRINTF("-32767",
+               "%i", -32767);
+  TEST_SPRINTF("30",
+               "%li", 30L);
+  TEST_SPRINTF("-2147483647",
+               "%li", -2147483647L);
+  TEST_SPRINTF("2147483647",
+               "%li", 2147483647L);
+  TEST_SPRINTF("30",
+               "%lli", 30LL);
+  TEST_SPRINTF("-9223372036854775807",
+               "%lli", -9223372036854775807LL);
+  TEST_SPRINTF("9223372036854775807",
+               "%lli", 9223372036854775807LL);
+  TEST_SPRINTF("100000",
+               "%lu", 100000L);
+  TEST_SPRINTF("4294967295",
+               "%lu", 0xFFFFFFFFL);
+  TEST_SPRINTF("281474976710656",
+               "%llu", 281474976710656LLU);
+  TEST_SPRINTF("18446744073709551615",
+               "%llu", 18446744073709551615LLU);
+  TEST_SPRINTF("2147483647",
+               "%zu", 2147483647UL);
+  TEST_SPRINTF("2147483647",
+               "%zd", 2147483647UL);
   if (sizeof(size_t) == sizeof(long)) {
-    test::sprintf(buffer, "%zi", -2147483647L);
-    REQUIRE(!strcmp(buffer, "-2147483647"));
+    TEST_SPRINTF("-2147483647",
+                 "%zi", -2147483647L);
   }
   else {
-    test::sprintf(buffer, "%zi", -2147483647LL);
-    REQUIRE(!strcmp(buffer, "-2147483647"));
+    TEST_SPRINTF("-2147483647",
+                 "%zi", -2147483647LL);
   }
 
-  test::sprintf(buffer, "%b", 60000);
-  REQUIRE(!strcmp(buffer, "1110101001100000"));
-
-  test::sprintf(buffer, "%lb", 12345678L);
-  REQUIRE(!strcmp(buffer, "101111000110000101001110"));
-
-  test::sprintf(buffer, "%o", 60000);
-  REQUIRE(!strcmp(buffer, "165140"));
-
-  test::sprintf(buffer, "%lo", 12345678L);
-  REQUIRE(!strcmp(buffer, "57060516"));
-
-  test::sprintf(buffer, "%lx", 0x12345678L);
-  REQUIRE(!strcmp(buffer, "12345678"));
-
-  test::sprintf(buffer, "%llx", 0x1234567891234567LLU);
-  REQUIRE(!strcmp(buffer, "1234567891234567"));
-
-  test::sprintf(buffer, "%lx", 0xabcdefabL);
-  REQUIRE(!strcmp(buffer, "abcdefab"));
-
-  test::sprintf(buffer, "%lX", 0xabcdefabL);
-  REQUIRE(!strcmp(buffer, "ABCDEFAB"));
-
-  test::sprintf(buffer, "%c", 'v');
-  REQUIRE(!strcmp(buffer, "v"));
-
-  test::sprintf(buffer, "%cv", 'w');
-  REQUIRE(!strcmp(buffer, "wv"));
-
-  test::sprintf(buffer, "%s", "A Test");
-  REQUIRE(!strcmp(buffer, "A Test"));
-
-  test::sprintf(buffer, "%hhu", 0xFFFFUL);
-  REQUIRE(!strcmp(buffer, "255"));
-
-  test::sprintf(buffer, "%hu", 0x123456UL);
-  REQUIRE(!strcmp(buffer, "13398"));
-
-  test::sprintf(buffer, "%s%hhi %hu", "Test", 10000, 0xFFFFFFFF);
-  REQUIRE(!strcmp(buffer, "Test16 65535"));
-
-  test::sprintf(buffer, "%tx", &buffer[10] - &buffer[0]);
-  REQUIRE(!strcmp(buffer, "a"));
-
+  TEST_SPRINTF("1110101001100000",
+               "%b", 60000);
+  TEST_SPRINTF("101111000110000101001110",
+               "%lb", 12345678L);
+  TEST_SPRINTF("165140",
+               "%o", 60000);
+  TEST_SPRINTF("57060516",
+               "%lo", 12345678L);
+  TEST_SPRINTF("12345678",
+               "%lx", 0x12345678L);
+  TEST_SPRINTF("1234567891234567",
+               "%llx", 0x1234567891234567LLU);
+  TEST_SPRINTF("abcdefab",
+               "%lx", 0xabcdefabL);
+  TEST_SPRINTF("ABCDEFAB",
+               "%lX", 0xabcdefabL);
+  TEST_SPRINTF("v",
+               "%c", 'v');
+  TEST_SPRINTF("wv",
+               "%cv", 'w');
+  TEST_SPRINTF("A Test",
+               "%s", "A Test");
+  TEST_SPRINTF("255",
+               "%hhu", 0xFFFFUL);
+  TEST_SPRINTF("13398",
+               "%hu", 0x123456UL);
+  TEST_SPRINTF("Test16 65535",
+               "%s%hhi %hu", "Test", 10000, 0xFFFFFFFF);
+  TEST_SPRINTF("a",
+               "%tx", &buffer[10] - &buffer[0]);
 // TBD
   if (sizeof(intmax_t) == sizeof(long)) {
-    test::sprintf(buffer, "%ji", -2147483647L);
-    REQUIRE(!strcmp(buffer, "-2147483647"));
+    TEST_SPRINTF("-2147483647",
+                 "%ji", -2147483647L);
   }
   else {
-    test::sprintf(buffer, "%ji", -2147483647LL);
-    REQUIRE(!strcmp(buffer, "-2147483647"));
+    TEST_SPRINTF("-2147483647",
+                 "%ji", -2147483647LL);
   }
 }
 
 
 TEST_CASE("pointer", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%p", (void*)0x1234U);
   if (sizeof(void*) == 4U) {
-    REQUIRE(!strcmp(buffer, "00001234"));
+    TEST_SPRINTF("00001234",
+                 "%p", (void*)0x1234U);
   }
   else {
-    REQUIRE(!strcmp(buffer, "0000000000001234"));
+    TEST_SPRINTF("0000000000001234",
+                 "%p", (void*)0x1234U);
   }
 
-  test::sprintf(buffer, "%p", (void*)0x12345678U);
   if (sizeof(void*) == 4U) {
-    REQUIRE(!strcmp(buffer, "12345678"));
+    TEST_SPRINTF("12345678",
+                 "%p", (void*)0x12345678U);
   }
   else {
-    REQUIRE(!strcmp(buffer, "0000000012345678"));
+    TEST_SPRINTF("0000000012345678",
+                 "%p", (void*)0x12345678U);
   }
 
-  test::sprintf(buffer, "%p-%p", (void*)0x12345678U, (void*)0x7EDCBA98U);
   if (sizeof(void*) == 4U) {
-    REQUIRE(!strcmp(buffer, "12345678-7EDCBA98"));
+    TEST_SPRINTF("12345678-7EDCBA98",
+                 "%p-%p", (void*)0x12345678U, (void*)0x7EDCBA98U);
   }
   else {
-    REQUIRE(!strcmp(buffer, "0000000012345678-000000007EDCBA98"));
+    TEST_SPRINTF("0000000012345678-000000007EDCBA98",
+                 "%p-%p", (void*)0x12345678U, (void*)0x7EDCBA98U);
   }
-
   if (sizeof(uintptr_t) == sizeof(uint64_t)) {
-    test::sprintf(buffer, "%p", (void*)(uintptr_t)0xFFFFFFFFU);
-    REQUIRE(!strcmp(buffer, "00000000FFFFFFFF"));
+    TEST_SPRINTF("00000000FFFFFFFF",
+                 "%p", (void*)(uintptr_t)0xFFFFFFFFU);
   }
   else {
-    test::sprintf(buffer, "%p", (void*)(uintptr_t)0xFFFFFFFFU);
-    REQUIRE(!strcmp(buffer, "FFFFFFFF"));
+    TEST_SPRINTF("FFFFFFFF",
+                 "%p", (void*)(uintptr_t)0xFFFFFFFFU);
   }
 }
 
 
 TEST_CASE("unknown flag", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%kmarco", 42, 37);
-  REQUIRE(!strcmp(buffer, "kmarco"));
+  TEST_SPRINTF("kmarco",
+               "%kmarco", 42, 37);
 }
 
 
 TEST_CASE("string length", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%.4s", "This is a test");
-  REQUIRE(!strcmp(buffer, "This"));
-
-  test::sprintf(buffer, "%.4s", "test");
-  REQUIRE(!strcmp(buffer, "test"));
-
-  test::sprintf(buffer, "%.7s", "123");
-  REQUIRE(!strcmp(buffer, "123"));
-
-  test::sprintf(buffer, "%.7s", "");
-  REQUIRE(!strcmp(buffer, ""));
-
-  test::sprintf(buffer, "%.4s%.2s", "123456", "abcdef");
-  REQUIRE(!strcmp(buffer, "1234ab"));
-
-  test::sprintf(buffer, "%.4.2s", "123456");
-  REQUIRE(!strcmp(buffer, ".2s"));
-
-  test::sprintf(buffer, "%.*s", 3, "123456");
-  REQUIRE(!strcmp(buffer, "123"));
+  TEST_SPRINTF("This",
+               "%.4s", "This is a test");
+  TEST_SPRINTF("test",
+               "%.4s", "test");
+  TEST_SPRINTF("123",
+               "%.7s", "123");
+  TEST_SPRINTF("",
+               "%.7s", "");
+  TEST_SPRINTF("1234ab",
+               "%.4s%.2s", "123456", "abcdef");
+  TEST_SPRINTF(".2s",
+               "%.4.2s", "123456");
+  TEST_SPRINTF("123",
+               "%.*s", 3, "123456");
 }
 
 
 TEST_CASE("buffer length", "[]" ) {
-  char buffer[100];
-  int ret;
+  TEST_DEF;
 
-  ret = test::snprintf(nullptr, 10, "%s", "Test");
+  ret = tested_snprintf(nullptr, 10, "%s", "Test");
   REQUIRE(ret == 4);
-  ret = test::snprintf(nullptr, 0, "%s", "Test");
+  ret = tested_snprintf(nullptr, 0, "%s", "Test");
   REQUIRE(ret == 4);
 
   buffer[0] = (char)0xA5;
-  ret = test::snprintf(buffer, 0, "%s", "Test");
+  ret = tested_snprintf(buffer, 0, "%s", "Test");
   REQUIRE(buffer[0] == (char)0xA5);
   REQUIRE(ret == 4);
 
   buffer[0] = (char)0xCC;
-  test::snprintf(buffer, 1, "%s", "Test");
+  tested_snprintf(buffer, 1, "%s", "Test");
   REQUIRE(buffer[0] == '\0');
 
-  test::snprintf(buffer, 2, "%s", "Hello");
-  REQUIRE(!strcmp(buffer, "H"));
+  TEST_SNPRINTF("H", 5,
+                2, "%s", "Hello");
 }
 
 
 TEST_CASE("ret value", "[]" ) {
-  char buffer[100] ;
-  int ret;
+  TEST_DEF;
 
-  ret = test::snprintf(buffer, 6, "0%s", "1234");
-  REQUIRE(!strcmp(buffer, "01234"));
-  REQUIRE(ret == 5);
+  TEST_SNPRINTF("01234", 5,
+                6, "0%s", "1234");
 
-  ret = test::snprintf(buffer, 6, "0%s", "12345");
-  REQUIRE(!strcmp(buffer, "01234"));
-  REQUIRE(ret == 6);  // '5' is truncated
+  TEST_SNPRINTF("01234", 6, // '5' is truncated
+                6, "0%s", "12345");
 
-  ret = test::snprintf(buffer, 6, "0%s", "1234567");
-  REQUIRE(!strcmp(buffer, "01234"));
-  REQUIRE(ret == 8);  // '567' are truncated
+  TEST_SNPRINTF("01234", 8, // '567' are truncated
+                6, "0%s", "1234567");
 
-  ret = test::snprintf(buffer, 10, "hello, world");
-  REQUIRE(ret == 12);
+  TEST_SNPRINTF(NULL, 12,
+                10, "hello, world");
 
-  ret = test::snprintf(buffer, 3, "%d", 10000);
-  REQUIRE(ret == 5);
-  REQUIRE(strlen(buffer) == 2U);
-  REQUIRE(buffer[0] == '1');
-  REQUIRE(buffer[1] == '0');
-  REQUIRE(buffer[2] == '\0');
+  TEST_SNPRINTF("10", 5,
+                3, "%d", 10000);
 }
 
 
 TEST_CASE("misc", "[]" ) {
-  char buffer[100];
+  TEST_DEF;
 
-  test::sprintf(buffer, "%u%u%ctest%d %s", 5, 3000, 'a', -20, "bit");
-  REQUIRE(!strcmp(buffer, "53000atest-20 bit"));
-
-  test::sprintf(buffer, "%.*f", 2, 0.33333333);
-  REQUIRE(!strcmp(buffer, "0.33"));
-
-  test::sprintf(buffer, "%.*d", -1, 1);
-  REQUIRE(!strcmp(buffer, "1"));
-
-  test::sprintf(buffer, "%.3s", "foobar");
-  REQUIRE(!strcmp(buffer, "foo"));
-
-  test::sprintf(buffer, "% .0d", 0);
-  REQUIRE(!strcmp(buffer, " "));
-
-  test::sprintf(buffer, "%10.5d", 4);
-  REQUIRE(!strcmp(buffer, "     00004"));
-
-  test::sprintf(buffer, "%*sx", -3, "hi");
-  REQUIRE(!strcmp(buffer, "hi x"));
-
+  TEST_SPRINTF("53000atest-20 bit",
+               "%u%u%ctest%d %s", 5, 3000, 'a', -20, "bit");
+  TEST_SPRINTF("0.33",
+               "%.*f", 2, 0.33333333);
+  TEST_SPRINTF("1",
+               "%.*d", -1, 1);
+  TEST_SPRINTF("foo",
+               "%.3s", "foobar");
+  TEST_SPRINTF(" ",
+               "% .0d", 0);
+  TEST_SPRINTF("     00004",
+               "%10.5d", 4);
+  TEST_SPRINTF("hi x",
+               "%*sx", -3, "hi");
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
-  test::sprintf(buffer, "%.*g", 2, 0.33333333);
-  REQUIRE(!strcmp(buffer, "0.33"));
-
-  test::sprintf(buffer, "%.*e", 2, 0.33333333);
-  REQUIRE(!strcmp(buffer, "3.33e-01"));
+  TEST_SPRINTF("0.33",
+               "%.*g", 2, 0.33333333);
+  TEST_SPRINTF("3.33e-01",
+               "%.*e", 2, 0.33333333);
 #endif
 }


### PR DESCRIPTION
Build printf using C
Convert most tests in test_suite to use macro
Fix catch2

New tests use CHECK now, but it may be reverted easily back to REQUIRE. 