### PR TITLE
Do not assume char is always signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The length sub-specifier modifies the length of the data type.
 | Length | d i  | u o x X |
 |--------|------|---------|
 | (none) | int  | unsigned int |
-| hh     | char | unsigned char |
+| hh     | signed char | unsigned char |
 | h      | short int | unsigned short int |
 | l      | long int | unsigned long int |
 | ll     | long long int | unsigned long long int (if PRINTF_SUPPORT_LONG_LONG is defined) |

--- a/printf.c
+++ b/printf.c
@@ -732,7 +732,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
             idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long)(value > 0 ? value : 0 - value), value < 0, base, precision, width, flags);
           }
           else {
-            const int value = (flags & FLAGS_CHAR) ? (char)va_arg(va, int) : (flags & FLAGS_SHORT) ? (short int)va_arg(va, int) : va_arg(va, int);
+            const int value = (flags & FLAGS_CHAR) ? (signed char)va_arg(va, int) : (flags & FLAGS_SHORT) ? (short int)va_arg(va, int) : va_arg(va, int);
             idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)(value > 0 ? value : 0 - value), value < 0, base, precision, width, flags);
           }
         }


### PR DESCRIPTION
This is platform-dependent and having it wrong makes the PRId8 and PRIi8 macros print int8_t values as unsigned on some platforms.