### PR TITLE
Add __io_lock() and __io_unlock() functions to lock io functions

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -861,11 +861,13 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 
 int printf_(const char* format, ...)
 {
+  __io_lock();
   va_list va;
   va_start(va, format);
   char buffer[1];
   const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
   va_end(va);
+  __io_unlock();
   return ret;
 }
 

--- a/printf.h
+++ b/printf.h
@@ -40,6 +40,17 @@
 extern "C" {
 #endif
 
+/**
+ * Lock the printf to avoid collision when multiple threads/cores try to output strings/characters.
+ * This function can implement a mutex, semaphore or whatever lock.
+ */
+void __io_lock();
+
+/**
+ * Unlock the printf, release the lock, semaphore or mutex used to lock printf.
+ * This function releases the mutex, semaphore or whatever lock used previously.
+ */
+void __io_unlock();
 
 /**
  * Output a character to a custom device like UART, used by the printf() function


### PR DESCRIPTION
Great implementation of printf. It is useful for our project in FreeRTOS.
We are currently using it, and would like to improve it adding lock and unlock functions at high level in functions like printf, sprintf to avoid collisions.
That is because multiple threads could call printf without having locks above printf.
The solution might be to use to have locks in the function _putchar, but it is very costly in terms of performance and time.
This kind of lock is better since it allows to send a full string before another thread/core messes up with it.

And of course the locks can be defined by users. Depending on architectures and/or OS, they can be mutexex, semaphores or simple locks using TAS/CAS,...