### PR TITLE
Add ability to skip comma flag even if no comma output implemented

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -110,6 +110,7 @@
 #define FLAGS_LONG_LONG (1U <<  9U)
 #define FLAGS_PRECISION (1U << 10U)
 #define FLAGS_ADAPT_EXP (1U << 11U)
+#define FLAGS_COMMA     (1U << 12U)
 
 
 // import float.h for DBL_MAX
@@ -602,12 +603,13 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
     flags = 0U;
     do {
       switch (*format) {
-        case '0': flags |= FLAGS_ZEROPAD; format++; n = 1U; break;
-        case '-': flags |= FLAGS_LEFT;    format++; n = 1U; break;
-        case '+': flags |= FLAGS_PLUS;    format++; n = 1U; break;
-        case ' ': flags |= FLAGS_SPACE;   format++; n = 1U; break;
-        case '#': flags |= FLAGS_HASH;    format++; n = 1U; break;
-        default :                                   n = 0U; break;
+        case  '0': flags |= FLAGS_ZEROPAD; format++; n = 1U; break;
+        case  '-': flags |= FLAGS_LEFT;    format++; n = 1U; break;
+        case  '+': flags |= FLAGS_PLUS;    format++; n = 1U; break;
+        case  ' ': flags |= FLAGS_SPACE;   format++; n = 1U; break;
+        case  '#': flags |= FLAGS_HASH;    format++; n = 1U; break;
+        case '\'': flags |= FLAGS_COMMA;   format++; n = 1U; break;
+        default  :                                   n = 0U; break;
       }
     } while (n);
 

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -10,10 +10,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -272,6 +272,76 @@ TEST_CASE("+ flag", "[]" ) {
   REQUIRE(!strcmp(buffer, "x"));
 
   test::sprintf(buffer, "%+.0d", 0);
+  REQUIRE(!strcmp(buffer, "+"));
+}
+
+
+// Note: copy and pasted from "+ flag".
+// Todo: Implement output of comma e.g. if environment variable is set due to lack of locale?
+TEST_CASE("' flag", "[]" ) {
+  char buffer[100];
+
+  test::sprintf(buffer, "%'+d", 42);
+  REQUIRE(!strcmp(buffer, "+42"));
+
+  test::sprintf(buffer, "%'+d", -42);
+  REQUIRE(!strcmp(buffer, "-42"));
+
+  test::sprintf(buffer, "%'+5d", 42);
+  REQUIRE(!strcmp(buffer, "  +42"));
+
+  test::sprintf(buffer, "%'+5d", -42);
+  REQUIRE(!strcmp(buffer, "  -42"));
+
+  test::sprintf(buffer, "%'+15d", 42);
+  REQUIRE(!strcmp(buffer, "            +42"));
+
+  test::sprintf(buffer, "%'+15d", -42);
+  REQUIRE(!strcmp(buffer, "            -42"));
+
+  test::sprintf(buffer, "%'+s", "Hello testing");
+  REQUIRE(!strcmp(buffer, "Hello testing"));
+
+  test::sprintf(buffer, "%'+d", 1024);
+  REQUIRE(!strcmp(buffer, "+1024"));
+
+  test::sprintf(buffer, "%'+d", -1024);
+  REQUIRE(!strcmp(buffer, "-1024"));
+
+  test::sprintf(buffer, "%'+i", 1024);
+  REQUIRE(!strcmp(buffer, "+1024"));
+
+  test::sprintf(buffer, "%'+i", -1024);
+  REQUIRE(!strcmp(buffer, "-1024"));
+
+  test::sprintf(buffer, "%'+u", 1024);
+  REQUIRE(!strcmp(buffer, "1024"));
+
+  test::sprintf(buffer, "%'+u", 4294966272U);
+  REQUIRE(!strcmp(buffer, "4294966272"));
+
+  test::sprintf(buffer, "%'+o", 511);
+  REQUIRE(!strcmp(buffer, "777"));
+
+  test::sprintf(buffer, "%'+o", 4294966785U);
+  REQUIRE(!strcmp(buffer, "37777777001"));
+
+  test::sprintf(buffer, "%'+x", 305441741);
+  REQUIRE(!strcmp(buffer, "1234abcd"));
+
+  test::sprintf(buffer, "%'+x", 3989525555U);
+  REQUIRE(!strcmp(buffer, "edcb5433"));
+
+  test::sprintf(buffer, "%'+X", 305441741);
+  REQUIRE(!strcmp(buffer, "1234ABCD"));
+
+  test::sprintf(buffer, "%'+X", 3989525555U);
+  REQUIRE(!strcmp(buffer, "EDCB5433"));
+
+  test::sprintf(buffer, "%'+c", 'x');
+  REQUIRE(!strcmp(buffer, "x"));
+
+  test::sprintf(buffer, "%'+.0d", 0);
   REQUIRE(!strcmp(buffer, "+"));
 }
 


### PR DESCRIPTION
Addresses half of issue #71 by adding ability to ignore a comma flag -- e.g. `#'d` -- and not interpret it literally. The result is as if the comma flag is not present, e.g. `#d`. All existing tests work, and added a new test section for the comma flag.

This pull request at least makes this implementation of `printf()` compatible with existing code which uses the comma flag... At least seg faults and/or unwanted output no longer occur. Next step will be to implement the comma output with some kind of mechanism to turn it on; environment variable?