### PR TITLE
cstdio name collision solution

### DIFF
--- a/printf.h
+++ b/printf.h
@@ -40,7 +40,11 @@
 extern "C" {
 #endif
 
-
+#if defined(PRINTF_FUNCTION_RENAME)
+	#define _PRINTF_GET_FNAME(base)  PRINTF_FUNCTION_RENAME(base)
+#else
+	#define _PRINTF_GET_FNAME(base)  mp_base##
+#endif
 /**
  * Output a character to a custom device like UART, used by the printf() function
  * This function is declared here only. You have to write your custom implementation somewhere
@@ -57,7 +61,7 @@ void _putchar(char character);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
-#define printf printf_
+#define printf_ _PRINTF_GET_FNAME(printf)
 int printf_(const char* format, ...);
 
 
@@ -68,7 +72,7 @@ int printf_(const char* format, ...);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-#define sprintf sprintf_
+#define sprintf_ _PRINTF_GET_FNAME(sprintf)
 int sprintf_(char* buffer, const char* format, ...);
 
 
@@ -82,8 +86,8 @@ int sprintf_(char* buffer, const char* format, ...);
  *         null character. A value equal or larger than count indicates truncation. Only when the returned value
  *         is non-negative and less than count, the string has been completely written.
  */
-#define snprintf  snprintf_
-#define vsnprintf vsnprintf_
+#define snprintf_ _PRINTF_GET_FNAME(snprintf)
+#define vsnprintf_ _PRINTF_GET_FNAME(vsnprintf)
 int  snprintf_(char* buffer, size_t count, const char* format, ...);
 int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
@@ -94,7 +98,7 @@ int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
  * \param va A value identifying a variable arguments list
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-#define vprintf vprintf_
+#define vprintf_ _PRINTF_GET_FNAME(vprintf)
 int vprintf_(const char* format, va_list va);
 
 

--- a/printf.h
+++ b/printf.h
@@ -43,7 +43,7 @@ extern "C" {
 #if defined(PRINTF_FUNCTION_RENAME)
 	#define _PRINTF_GET_FNAME(base)  PRINTF_FUNCTION_RENAME(base)
 #else
-	#define _PRINTF_GET_FNAME(base)  mp_base##
+	#define _PRINTF_GET_FNAME(base)  mp_##base
 #endif
 /**
  * Output a character to a custom device like UART, used by the printf() function


### PR DESCRIPTION
I had issues with name collision when including `cstdio` #66. Solution with mapping to wrap functions is taken from [bisqwit/tinyprintf](https://github.com/bisqwit/tinyprintf). What do you think about it?

Consider this a quick POC rather than a final code solution.