### PR TITLE
added vsprintf() - sprintf with variable arguments list

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -896,6 +896,10 @@ int vprintf_(const char* format, va_list va)
   return _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
 }
 
+int vsprintf_(char* buffer, const char* format, va_list va)
+{
+  return _vsnprintf(_out_buffer, buffer, (size_t)-1, format, va);
+}
 
 int vsnprintf_(char* buffer, size_t count, const char* format, va_list va)
 {

--- a/printf.h
+++ b/printf.h
@@ -62,14 +62,17 @@ int printf_(const char* format, ...);
 
 
 /**
- * Tiny sprintf implementation
+ * Tiny sprintf/vsprintf implementation
  * Due to security reasons (buffer overflow) YOU SHOULD CONSIDER USING (V)SNPRINTF INSTEAD!
  * \param buffer A pointer to the buffer where to store the formatted string. MUST be big enough to store the output!
  * \param format A string that specifies the format of the output
+ * \param va A value identifying a variable arguments list
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-#define sprintf sprintf_
-int sprintf_(char* buffer, const char* format, ...);
+#define sprintf  sprintf_
+#define vsprintf vsprintf_
+int  sprintf_(char* buffer, const char* format, ...);
+int vsprintf_(char* buffer, const char* format, va_list va);
 
 
 /**


### PR DESCRIPTION
Hi, thanks for the lib!

I know that size-unsafe functions are not to be used. In one of my projects some 3rd party lib used both `vsprintf()` and `vsnprintf()`. Which meant that all `vsnprintf()` were successfully replaced by your implementation, but `vsprintf()` was used from default newlib (in my case for STM32 MCU). This led to lot of confusion until I discovered there's no `vsprintf()` implementation. 

That's why i added `vsprintf()` function just so that all of the `[v][s][n]printf()` options are supported and replaced by the lib.

P. S. I like to use [this header file](https://github.com/git/git/blob/master/banned.h) from GitHub to check for banned/unsafe functions :)