### PR TITLE
Refactor: C90 support.

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -1,34 +1,34 @@
-///////////////////////////////////////////////////////////////////////////////
-// \author (c) Marco Paland (info@paland.com)
-//             2014-2019, PALANDesign Hannover, Germany
-//
-// \license The MIT License (MIT)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-// \brief Tiny printf, sprintf and (v)snprintf implementation, optimized for speed on
-//        embedded systems with a very limited resources. These routines are thread
-//        safe and reentrant!
-//        Use this instead of the bloated standard/newlib printf cause these use
-//        malloc for printf (and may not be thread safe).
-//
-///////////////////////////////////////////////////////////////////////////////
+/******************************************************************************
+ * \author (c) Marco Paland (info@paland.com)
+ *             2014-2019, PALANDesign Hannover, Germany
+ *
+ * \license The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * \brief Tiny printf, sprintf and (v)snprintf implementation, optimized for speed on
+ *        embedded systems with a very limited resources. These routines are thread
+ *        safe and reentrant!
+ *        Use this instead of the bloated standard/newlib printf cause these use
+ *        malloc for printf (and may not be thread safe).
+ *
+ *****************************************************************************/
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -36,68 +36,68 @@
 #include "printf.h"
 
 
-// define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H ...) to include the
-// printf_config.h header file
-// default: undefined
+/* define this globally (e.g. gcc -DPRINTF_INCLUDE_CONFIG_H ...) to include the
+ * printf_config.h header file
+ * default: undefined */
 #ifdef PRINTF_INCLUDE_CONFIG_H
 #include "printf_config.h"
 #endif
 
 
-// 'ntoa' conversion buffer size, this must be big enough to hold one converted
-// numeric number including padded zeros (dynamically created on stack)
-// default: 32 byte
+/* 'ntoa' conversion buffer size, this must be big enough to hold one converted
+ * numeric number including padded zeros (dynamically created on stack)
+ * default: 32 byte */
 #ifndef PRINTF_NTOA_BUFFER_SIZE
 #define PRINTF_NTOA_BUFFER_SIZE    32U
 #endif
 
-// 'ftoa' conversion buffer size, this must be big enough to hold one converted
-// float number including padded zeros (dynamically created on stack)
-// default: 32 byte
+/* 'ftoa' conversion buffer size, this must be big enough to hold one converted
+ * float number including padded zeros (dynamically created on stack)
+ * default: 32 byte */
 #ifndef PRINTF_FTOA_BUFFER_SIZE
 #define PRINTF_FTOA_BUFFER_SIZE    32U
 #endif
 
-// support for the floating point type (%f)
-// default: activated
+/* support for the floating point type (%f)
+ * default: activated */
 #ifndef PRINTF_DISABLE_SUPPORT_FLOAT
 #define PRINTF_SUPPORT_FLOAT
 #endif
 
-// support for exponential floating point notation (%e/%g)
-// default: activated
+/* support for exponential floating point notation (%e/%g)
+ * default: activated */
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
 #define PRINTF_SUPPORT_EXPONENTIAL
 #endif
 
-// define the default floating point precision
-// default: 6 digits
+/* define the default floating point precision
+ * default: 6 digits */
 #ifndef PRINTF_DEFAULT_FLOAT_PRECISION
 #define PRINTF_DEFAULT_FLOAT_PRECISION  6U
 #endif
 
-// define the largest float suitable to print with %f
-// default: 1e9
+/* define the largest float suitable to print with %f
+ * default: 1e9 */
 #ifndef PRINTF_MAX_FLOAT
 #define PRINTF_MAX_FLOAT  1e9
 #endif
 
-// support for the long long types (%llu or %p)
-// default: activated
+/* support for the long long types (%llu or %p)
+ * default: activated */
 #ifndef PRINTF_DISABLE_SUPPORT_LONG_LONG
 #define PRINTF_SUPPORT_LONG_LONG
 #endif
 
-// support for the ptrdiff_t type (%t)
-// ptrdiff_t is normally defined in <stddef.h> as long or long long type
-// default: activated
+/* support for the ptrdiff_t type (%t)
+ * ptrdiff_t is normally defined in <stddef.h> as long or long long type
+ * default: activated */
 #ifndef PRINTF_DISABLE_SUPPORT_PTRDIFF_T
 #define PRINTF_SUPPORT_PTRDIFF_T
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
+/*****************************************************************************/
 
-// internal flag definitions
+/* internal flag definitions */
 #define FLAGS_ZEROPAD   (1U <<  0U)
 #define FLAGS_LEFT      (1U <<  1U)
 #define FLAGS_PLUS      (1U <<  2U)
@@ -112,24 +112,24 @@
 #define FLAGS_ADAPT_EXP (1U << 11U)
 
 
-// import float.h for DBL_MAX
+/* import float.h for DBL_MAX */
 #if defined(PRINTF_SUPPORT_FLOAT)
 #include <float.h>
 #endif
 
 
-// output function type
+/* output function type */
 typedef void (*out_fct_type)(char character, void* buffer, size_t idx, size_t maxlen);
 
 
-// wrapper (used as buffer) for output function type
+/* wrapper (used as buffer) for output function type */
 typedef struct {
   void  (*fct)(char character, void* arg);
   void* arg;
 } out_fct_wrap_type;
 
 
-// internal buffer output
+/* internal buffer output */
 static inline void _out_buffer(char character, void* buffer, size_t idx, size_t maxlen)
 {
   if (idx < maxlen) {
@@ -138,14 +138,14 @@ static inline void _out_buffer(char character, void* buffer, size_t idx, size_t 
 }
 
 
-// internal null output
+/* internal null output */
 static inline void _out_null(char character, void* buffer, size_t idx, size_t maxlen)
 {
   (void)character; (void)buffer; (void)idx; (void)maxlen;
 }
 
 
-// internal _putchar wrapper
+/* internal _putchar wrapper */
 static inline void _out_char(char character, void* buffer, size_t idx, size_t maxlen)
 {
   (void)buffer; (void)idx; (void)maxlen;
@@ -155,19 +155,21 @@ static inline void _out_char(char character, void* buffer, size_t idx, size_t ma
 }
 
 
-// internal output function wrapper
+/* internal output function wrapper */
 static inline void _out_fct(char character, void* buffer, size_t idx, size_t maxlen)
 {
   (void)idx; (void)maxlen;
   if (character) {
-    // buffer is the output fct pointer
+    /* buffer is the output fct pointer */
     ((out_fct_wrap_type*)buffer)->fct(character, ((out_fct_wrap_type*)buffer)->arg);
   }
 }
 
 
-// internal secure strlen
-// \return The length of the string (excluding the terminating 0) limited by 'maxsize'
+/**
+ * internal secure strlen
+ * \return The length of the string (excluding the terminating 0) limited by 'maxsize'
+ */
 static inline unsigned int _strnlen_s(const char* str, size_t maxsize)
 {
   const char* s;
@@ -176,15 +178,17 @@ static inline unsigned int _strnlen_s(const char* str, size_t maxsize)
 }
 
 
-// internal test if char is a digit (0-9)
-// \return true if char is a digit
+/**
+ * internal test if char is a digit (0-9)
+ * \return true if char is a digit
+ */
 static inline bool _is_digit(char ch)
 {
   return (ch >= '0') && (ch <= '9');
 }
 
 
-// internal ASCII string to unsigned int conversion
+/* internal ASCII string to unsigned int conversion */
 static unsigned int _atoi(const char** str)
 {
   unsigned int i = 0U;
@@ -195,24 +199,24 @@ static unsigned int _atoi(const char** str)
 }
 
 
-// output the specified string in reverse, taking care of any zero-padding
+/* output the specified string in reverse, taking care of any zero-padding */
 static size_t _out_rev(out_fct_type out, char* buffer, size_t idx, size_t maxlen, const char* buf, size_t len, unsigned int width, unsigned int flags)
 {
   const size_t start_idx = idx;
 
-  // pad spaces up to given width
+  /* pad spaces up to given width */
   if (!(flags & FLAGS_LEFT) && !(flags & FLAGS_ZEROPAD)) {
     for (size_t i = len; i < width; i++) {
       out(' ', buffer, idx++, maxlen);
     }
   }
 
-  // reverse string
+  /* reverse string */
   while (len) {
     out(buf[--len], buffer, idx++, maxlen);
   }
 
-  // append pad spaces up to given width
+  /* append pad spaces up to given width */
   if (flags & FLAGS_LEFT) {
     while (idx - start_idx < width) {
       out(' ', buffer, idx++, maxlen);
@@ -223,10 +227,10 @@ static size_t _out_rev(out_fct_type out, char* buffer, size_t idx, size_t maxlen
 }
 
 
-// internal itoa format
+/* internal itoa format */
 static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t maxlen, char* buf, size_t len, bool negative, unsigned int base, unsigned int prec, unsigned int width, unsigned int flags)
 {
-  // pad leading zeros
+  /* pad leading zeros */
   if (!(flags & FLAGS_LEFT)) {
     if (width && (flags & FLAGS_ZEROPAD) && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
       width--;
@@ -239,7 +243,7 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
     }
   }
 
-  // handle hash
+  /* handle hash */
   if (flags & FLAGS_HASH) {
     if (!(flags & FLAGS_PRECISION) && len && ((len == prec) || (len == width))) {
       len--;
@@ -266,7 +270,7 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
       buf[len++] = '-';
     }
     else if (flags & FLAGS_PLUS) {
-      buf[len++] = '+';  // ignore the space if the '+' exists
+      buf[len++] = '+';  /* ignore the space if the '+' exists */
     }
     else if (flags & FLAGS_SPACE) {
       buf[len++] = ' ';
@@ -277,18 +281,18 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
 }
 
 
-// internal itoa for 'long' type
+/* internal itoa for 'long' type */
 static size_t _ntoa_long(out_fct_type out, char* buffer, size_t idx, size_t maxlen, unsigned long value, bool negative, unsigned long base, unsigned int prec, unsigned int width, unsigned int flags)
 {
   char buf[PRINTF_NTOA_BUFFER_SIZE];
   size_t len = 0U;
 
-  // no hash for 0 values
+  /* no hash for 0 values */
   if (!value) {
     flags &= ~FLAGS_HASH;
   }
 
-  // write if precision != 0 and value is != 0
+  /* write if precision != 0 and value is != 0 */
   if (!(flags & FLAGS_PRECISION) || value) {
     do {
       const char digit = (char)(value % base);
@@ -301,19 +305,19 @@ static size_t _ntoa_long(out_fct_type out, char* buffer, size_t idx, size_t maxl
 }
 
 
-// internal itoa for 'long long' type
+/* internal itoa for 'long long' type */
 #if defined(PRINTF_SUPPORT_LONG_LONG)
 static size_t _ntoa_long_long(out_fct_type out, char* buffer, size_t idx, size_t maxlen, unsigned long long value, bool negative, unsigned long long base, unsigned int prec, unsigned int width, unsigned int flags)
 {
   char buf[PRINTF_NTOA_BUFFER_SIZE];
   size_t len = 0U;
 
-  // no hash for 0 values
+  /* no hash for 0 values */
   if (!value) {
     flags &= ~FLAGS_HASH;
   }
 
-  // write if precision != 0 and value is != 0
+  /* write if precision != 0 and value is != 0 */
   if (!(flags & FLAGS_PRECISION) || value) {
     do {
       const char digit = (char)(value % base);
@@ -324,28 +328,28 @@ static size_t _ntoa_long_long(out_fct_type out, char* buffer, size_t idx, size_t
 
   return _ntoa_format(out, buffer, idx, maxlen, buf, len, negative, (unsigned int)base, prec, width, flags);
 }
-#endif  // PRINTF_SUPPORT_LONG_LONG
+#endif  /* PRINTF_SUPPORT_LONG_LONG */
 
 
 #if defined(PRINTF_SUPPORT_FLOAT)
 
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
-// forward declaration so that _ftoa can switch to exp notation for values > PRINTF_MAX_FLOAT
+/* forward declaration so that _ftoa can switch to exp notation for values > PRINTF_MAX_FLOAT */
 static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags);
 #endif
 
 
-// internal ftoa for fixed decimal floating point
+/* internal ftoa for fixed decimal floating point */
 static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags)
 {
   char buf[PRINTF_FTOA_BUFFER_SIZE];
   size_t len  = 0U;
   double diff = 0.0;
 
-  // powers of 10
+  /* powers of 10 */
   static const double pow10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
 
-  // test for special values
+  /* test for special values */
   if (value != value)
     return _out_rev(out, buffer, idx, maxlen, "nan", 3, width, flags);
   if (value < -DBL_MAX)
@@ -353,8 +357,8 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   if (value > DBL_MAX)
     return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4U : 3U, width, flags);
 
-  // test for very large values
-  // standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad
+  /* test for very large values
+  /* standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad */
   if ((value > PRINTF_MAX_FLOAT) || (value < -PRINTF_MAX_FLOAT)) {
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
     return _etoa(out, buffer, idx, maxlen, value, prec, width, flags);
@@ -363,18 +367,18 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 #endif
   }
 
-  // test for negative
+  /* test for negative */
   bool negative = false;
   if (value < 0) {
     negative = true;
     value = 0 - value;
   }
 
-  // set default precision, if not set explicitly
+  /* set default precision, if not set explicitly */
   if (!(flags & FLAGS_PRECISION)) {
     prec = PRINTF_DEFAULT_FLOAT_PRECISION;
   }
-  // limit precision to 9, cause a prec >= 10 can lead to overflow errors
+  /* limit precision to 9, cause a prec >= 10 can lead to overflow errors */
   while ((len < PRINTF_FTOA_BUFFER_SIZE) && (prec > 9U)) {
     buf[len++] = '0';
     prec--;
@@ -387,7 +391,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 
   if (diff > 0.5) {
     ++frac;
-    // handle rollover, e.g. case 0.99 with prec 1 is 1.0
+    /* handle rollover, e.g. case 0.99 with prec 1 is 1.0 */
     if (frac >= pow10[prec]) {
       frac = 0;
       ++whole;
@@ -396,21 +400,21 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   else if (diff < 0.5) {
   }
   else if ((frac == 0U) || (frac & 1U)) {
-    // if halfway, round up if odd OR if last digit is 0
+    /* if halfway, round up if odd OR if last digit is 0 */
     ++frac;
   }
 
   if (prec == 0U) {
     diff = value - (double)whole;
     if ((!(diff < 0.5) || (diff > 0.5)) && (whole & 1)) {
-      // exactly 0.5 and ODD, then round up
-      // 1.5 -> 2, but 2.5 -> 2
+      /* exactly 0.5 and ODD, then round up
+       * 1.5 -> 2, but 2.5 -> 2 */
       ++whole;
     }
   }
   else {
     unsigned int count = prec;
-    // now do fractional part, as an unsigned number
+    /* now do fractional part, as an unsigned number */
     while (len < PRINTF_FTOA_BUFFER_SIZE) {
       --count;
       buf[len++] = (char)(48U + (frac % 10U));
@@ -418,17 +422,17 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
         break;
       }
     }
-    // add extra 0s
+    /* add extra 0s */
     while ((len < PRINTF_FTOA_BUFFER_SIZE) && (count-- > 0U)) {
       buf[len++] = '0';
     }
     if (len < PRINTF_FTOA_BUFFER_SIZE) {
-      // add decimal
+      /* add decimal */
       buf[len++] = '.';
     }
   }
 
-  // do whole part, number is reversed
+  /* do whole part, number is reversed */
   while (len < PRINTF_FTOA_BUFFER_SIZE) {
     buf[len++] = (char)(48 + (whole % 10));
     if (!(whole /= 10)) {
@@ -436,7 +440,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
     }
   }
 
-  // pad leading zeros
+  /* pad leading zeros */
   if (!(flags & FLAGS_LEFT) && (flags & FLAGS_ZEROPAD)) {
     if (width && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
       width--;
@@ -451,7 +455,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
       buf[len++] = '-';
     }
     else if (flags & FLAGS_PLUS) {
-      buf[len++] = '+';  // ignore the space if the '+' exists
+      buf[len++] = '+';  /* ignore the space if the '+' exists */
     }
     else if (flags & FLAGS_SPACE) {
       buf[len++] = ' ';
@@ -463,56 +467,56 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
 
 
 #if defined(PRINTF_SUPPORT_EXPONENTIAL)
-// internal ftoa variant for exponential floating-point type, contributed by Martijn Jasperse <m.jasperse@gmail.com>
+/* internal ftoa variant for exponential floating-point type, contributed by Martijn Jasperse <m.jasperse@gmail.com> */
 static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags)
 {
-  // check for NaN and special values
+  /* check for NaN and special values */
   if ((value != value) || (value > DBL_MAX) || (value < -DBL_MAX)) {
     return _ftoa(out, buffer, idx, maxlen, value, prec, width, flags);
   }
 
-  // determine the sign
+  /* determine the sign */
   const bool negative = value < 0;
   if (negative) {
     value = -value;
   }
 
-  // default precision
+  /* default precision */
   if (!(flags & FLAGS_PRECISION)) {
     prec = PRINTF_DEFAULT_FLOAT_PRECISION;
   }
 
-  // determine the decimal exponent
-  // based on the algorithm by David Gay (https://www.ampl.com/netlib/fp/dtoa.c)
+  /* determine the decimal exponent
+   * based on the algorithm by David Gay (https://www.ampl.com/netlib/fp/dtoa.c) */
   union {
     uint64_t U;
     double   F;
   } conv;
 
   conv.F = value;
-  int exp2 = (int)((conv.U >> 52U) & 0x07FFU) - 1023;           // effectively log2
-  conv.U = (conv.U & ((1ULL << 52U) - 1U)) | (1023ULL << 52U);  // drop the exponent so conv.F is now in [1,2)
-  // now approximate log10 from the log2 integer part and an expansion of ln around 1.5
+  int exp2 = (int)((conv.U >> 52U) & 0x07FFU) - 1023;           /* effectively log2 */
+  conv.U = (conv.U & ((1ULL << 52U) - 1U)) | (1023ULL << 52U);  /* drop the exponent so conv.F is now in [1,2) */
+  /* now approximate log10 from the log2 integer part and an expansion of ln around 1.5 */
   int expval = (int)(0.1760912590558 + exp2 * 0.301029995663981 + (conv.F - 1.5) * 0.289529654602168);
-  // now we want to compute 10^expval but we want to be sure it won't overflow
+  /* now we want to compute 10^expval but we want to be sure it won't overflow */
   exp2 = (int)(expval * 3.321928094887362 + 0.5);
   const double z  = expval * 2.302585092994046 - exp2 * 0.6931471805599453;
   const double z2 = z * z;
   conv.U = (uint64_t)(exp2 + 1023) << 52U;
-  // compute exp(z) using continued fractions, see https://en.wikipedia.org/wiki/Exponential_function#Continued_fractions_for_ex
+  /* compute exp(z) using continued fractions, see https://en.wikipedia.org/wiki/Exponential_function#Continued_fractions_for_ex */
   conv.F *= 1 + 2 * z / (2 - z + (z2 / (6 + (z2 / (10 + z2 / 14)))));
-  // correct for rounding errors
+  /* correct for rounding errors */
   if (value < conv.F) {
     expval--;
     conv.F /= 10;
   }
 
-  // the exponent format is "%+03d" and largest value is "307", so set aside 4-5 characters
+  /* the exponent format is "%+03d" and largest value is "307", so set aside 4-5 characters */
   unsigned int minwidth = ((expval < 100) && (expval > -100)) ? 4U : 5U;
 
-  // in "%g" mode, "prec" is the number of *significant figures* not decimals
+  /* in "%g" mode, "prec" is the number of *significant figures* not decimals */
   if (flags & FLAGS_ADAPT_EXP) {
-    // do we want to fall-back to "%f" mode?
+    /* do we want to fall-back to "%f" mode? */
     if ((value >= 1e-4) && (value < 1e6)) {
       if ((int)prec > expval) {
         prec = (unsigned)((int)prec - expval - 1);
@@ -520,85 +524,85 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
       else {
         prec = 0;
       }
-      flags |= FLAGS_PRECISION;   // make sure _ftoa respects precision
-      // no characters in exponent
+      flags |= FLAGS_PRECISION;   /* make sure _ftoa respects precision */
+      /* no characters in exponent */
       minwidth = 0U;
       expval   = 0;
     }
     else {
-      // we use one sigfig for the whole part
+      /* we use one sigfig for the whole part */
       if ((prec > 0) && (flags & FLAGS_PRECISION)) {
         --prec;
       }
     }
   }
 
-  // will everything fit?
+  /* will everything fit? */
   unsigned int fwidth = width;
   if (width > minwidth) {
-    // we didn't fall-back so subtract the characters required for the exponent
+    /* we didn't fall-back so subtract the characters required for the exponent */
     fwidth -= minwidth;
   } else {
-    // not enough characters, so go back to default sizing
+    /* not enough characters, so go back to default sizing */
     fwidth = 0U;
   }
   if ((flags & FLAGS_LEFT) && minwidth) {
-    // if we're padding on the right, DON'T pad the floating part
+    /* if we're padding on the right, DON'T pad the floating part */
     fwidth = 0U;
   }
 
-  // rescale the float value
+  /* rescale the float value */
   if (expval) {
     value /= conv.F;
   }
 
-  // output the floating part
+  /* output the floating part */
   const size_t start_idx = idx;
   idx = _ftoa(out, buffer, idx, maxlen, negative ? -value : value, prec, fwidth, flags & ~FLAGS_ADAPT_EXP);
 
-  // output the exponent part
+  /* output the exponent part */
   if (minwidth) {
-    // output the exponential symbol
+    /* output the exponential symbol */
     out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
-    // output the exponent value
-    idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
-    // might need to right-pad spaces
+    /* output the exponent value
+     * idx = _ntoa_long(out, buffer, idx, maxlen, (expval < 0) ? -expval : expval, expval < 0, 10, 0, minwidth-1, FLAGS_ZEROPAD | FLAGS_PLUS);
+     * might need to right-pad spaces */
     if (flags & FLAGS_LEFT) {
       while (idx - start_idx < width) out(' ', buffer, idx++, maxlen);
     }
   }
   return idx;
 }
-#endif  // PRINTF_SUPPORT_EXPONENTIAL
-#endif  // PRINTF_SUPPORT_FLOAT
+#endif  /* PRINTF_SUPPORT_EXPONENTIAL */
+#endif  /* PRINTF_SUPPORT_FLOAT */
 
 
-// internal vsnprintf
+/* internal vsnprintf */
 static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const char* format, va_list va)
 {
   unsigned int flags, width, precision, n;
   size_t idx = 0U;
 
   if (!buffer) {
-    // use null output function
+    /* use null output function */
     out = _out_null;
   }
 
   while (*format)
   {
-    // format specifier?  %[flags][width][.precision][length]
+    /* format specifier?  %[flags][width][.precision][length] */
     if (*format != '%') {
-      // no
+      /* no */
       out(*format, buffer, idx++, maxlen);
       format++;
       continue;
     }
     else {
-      // yes, evaluate it
+      /* yes, evaluate it */
       format++;
     }
 
-    // evaluate flags
+    /* evaluate flags */
     flags = 0U;
     do {
       switch (*format) {
@@ -611,7 +615,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
       }
     } while (n);
 
-    // evaluate width field
+    /* evaluate width field */
     width = 0U;
     if (_is_digit(*format)) {
       width = _atoi(&format);
@@ -619,7 +623,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
     else if (*format == '*') {
       const int w = va_arg(va, int);
       if (w < 0) {
-        flags |= FLAGS_LEFT;    // reverse padding
+        flags |= FLAGS_LEFT;    /* reverse padding */
         width = (unsigned int)-w;
       }
       else {
@@ -628,7 +632,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
       format++;
     }
 
-    // evaluate precision field
+    /* evaluate precision field */
     precision = 0U;
     if (*format == '.') {
       flags |= FLAGS_PRECISION;
@@ -643,7 +647,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
       }
     }
 
-    // evaluate length field
+    /* evaluate length field */
     switch (*format) {
       case 'l' :
         flags |= FLAGS_LONG;
@@ -679,7 +683,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         break;
     }
 
-    // evaluate specifier
+    /* evaluate specifier */
     switch (*format) {
       case 'd' :
       case 'i' :
@@ -688,7 +692,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
       case 'X' :
       case 'o' :
       case 'b' : {
-        // set the base
+        /* set the base */
         unsigned int base;
         if (*format == 'x' || *format == 'X') {
           base = 16U;
@@ -701,26 +705,26 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         }
         else {
           base = 10U;
-          flags &= ~FLAGS_HASH;   // no hash for dec format
+          flags &= ~FLAGS_HASH;   /* no hash for dec format */
         }
-        // uppercase
+        /* uppercase */
         if (*format == 'X') {
           flags |= FLAGS_UPPERCASE;
         }
 
-        // no plus or space flag for u, x, X, o, b
+        /* no plus or space flag for u, x, X, o, b */
         if ((*format != 'i') && (*format != 'd')) {
           flags &= ~(FLAGS_PLUS | FLAGS_SPACE);
         }
 
-        // ignore '0' flag when precision is given
+        /* ignore '0' flag when precision is given */
         if (flags & FLAGS_PRECISION) {
           flags &= ~FLAGS_ZEROPAD;
         }
 
-        // convert the integer
+        /* convert the integer */
         if ((*format == 'i') || (*format == 'd')) {
-          // signed
+          /* signed */
           if (flags & FLAGS_LONG_LONG) {
 #if defined(PRINTF_SUPPORT_LONG_LONG)
             const long long value = va_arg(va, long long);
@@ -737,7 +741,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
           }
         }
         else {
-          // unsigned
+          /* unsigned */
           if (flags & FLAGS_LONG_LONG) {
 #if defined(PRINTF_SUPPORT_LONG_LONG)
             idx = _ntoa_long_long(out, buffer, idx, maxlen, va_arg(va, unsigned long long), false, base, precision, width, flags);
@@ -771,19 +775,19 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         idx = _etoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
         format++;
         break;
-#endif  // PRINTF_SUPPORT_EXPONENTIAL
-#endif  // PRINTF_SUPPORT_FLOAT
+#endif  /* PRINTF_SUPPORT_EXPONENTIAL */
+#endif  /* PRINTF_SUPPORT_FLOAT */
       case 'c' : {
         unsigned int l = 1U;
-        // pre padding
+        /* pre padding */
         if (!(flags & FLAGS_LEFT)) {
           while (l++ < width) {
             out(' ', buffer, idx++, maxlen);
           }
         }
-        // char output
+        /* char output */
         out((char)va_arg(va, int), buffer, idx++, maxlen);
-        // post padding
+        /* post padding */
         if (flags & FLAGS_LEFT) {
           while (l++ < width) {
             out(' ', buffer, idx++, maxlen);
@@ -796,7 +800,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
       case 's' : {
         const char* p = va_arg(va, char*);
         unsigned int l = _strnlen_s(p, precision ? precision : (size_t)-1);
-        // pre padding
+        /* pre padding */
         if (flags & FLAGS_PRECISION) {
           l = (l < precision ? l : precision);
         }
@@ -805,11 +809,11 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
             out(' ', buffer, idx++, maxlen);
           }
         }
-        // string output
+        /* string output */
         while ((*p != 0) && (!(flags & FLAGS_PRECISION) || precision--)) {
           out(*(p++), buffer, idx++, maxlen);
         }
-        // post padding
+        /* post padding */
         if (flags & FLAGS_LEFT) {
           while (l++ < width) {
             out(' ', buffer, idx++, maxlen);
@@ -849,15 +853,15 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
     }
   }
 
-  // termination
+  /* termination */
   out((char)0, buffer, idx < maxlen ? idx : maxlen - 1U, maxlen);
 
-  // return written chars without terminating \0
+  /* return written chars without terminating \0 */
   return (int)idx;
 }
 
 
-///////////////////////////////////////////////////////////////////////////////
+/*****************************************************************************/
 
 int printf_(const char* format, ...)
 {

--- a/printf.h
+++ b/printf.h
@@ -1,33 +1,33 @@
-///////////////////////////////////////////////////////////////////////////////
-// \author (c) Marco Paland (info@paland.com)
-//             2014-2019, PALANDesign Hannover, Germany
-//
-// \license The MIT License (MIT)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-// \brief Tiny printf, sprintf and snprintf implementation, optimized for speed on
-//        embedded systems with a very limited resources.
-//        Use this instead of bloated standard/newlib printf.
-//        These routines are thread safe and reentrant.
-//
-///////////////////////////////////////////////////////////////////////////////
+/******************************************************************************
+ * \author (c) Marco Paland (info@paland.com)
+ *             2014-2019, PALANDesign Hannover, Germany
+ *
+ * \license The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+ * THE SOFTWARE.
+ *
+ * \brief Tiny printf, sprintf and snprintf implementation, optimized for speed on
+ *        embedded systems with a very limited resources.
+ *        Use this instead of bloated standard/newlib printf.
+ *        These routines are thread safe and reentrant.
+ *
+ ******************************************************************************/
 
 #ifndef _PRINTF_H_
 #define _PRINTF_H_
@@ -114,4 +114,4 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
 #endif
 
 
-#endif  // _PRINTF_H_
+#endif  /* _PRINTF_H_ */

--- a/printf.h
+++ b/printf.h
@@ -1,33 +1,34 @@
-///////////////////////////////////////////////////////////////////////////////
-// \author (c) Marco Paland (info@paland.com)
-//             2014-2019, PALANDesign Hannover, Germany
-//
-// \license The MIT License (MIT)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-// \brief Tiny printf, sprintf and snprintf implementation, optimized for speed on
-//        embedded systems with a very limited resources.
-//        Use this instead of bloated standard/newlib printf.
-//        These routines are thread safe and reentrant.
-//
-///////////////////////////////////////////////////////////////////////////////
+/******************************************************************************
+*
+* \author (c) Marco Paland (info@paland.com)
+*             2014-2019, PALANDesign Hannover, Germany
+*
+* \license The MIT License (MIT)
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* \brief Tiny printf, sprintf and snprintf implementation, optimized for speed on
+*        embedded systems with a very limited resources.
+*        Use this instead of bloated standard/newlib printf.
+*        These routines are thread safe and reentrant.
+*
+******************************************************************************/
 
 #ifndef _PRINTF_H_
 #define _PRINTF_H_
@@ -114,4 +115,4 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
 #endif
 
 
-#endif  // _PRINTF_H_
+#endif  /* _PRINTF_H_ */


### PR DESCRIPTION
Refactor `printf.c` and `printf.h` to compile cleanly with `-std=c90 -W -Wall -Wextra -Wpedantic`.

Changes are:

- Using C style ( `/* ... */`) comments, not C++ style (`// ...`).
- Declaring all variables the the start of functions. This requires removes the `const` from some variables.
- Replacing `long long` with `int64_t` and `unsigned long long` with `uint64_t`.