### PR TITLE
bugfix

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -231,12 +231,12 @@ static size_t _ntoa_format(out_fct_type out, char* buffer, size_t idx, size_t ma
     if (width && (flags & FLAGS_ZEROPAD) && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
       width--;
     }
-    while ((len < prec) && (len < PRINTF_NTOA_BUFFER_SIZE)) {
-      buf[len++] = '0';
-    }
     while ((flags & FLAGS_ZEROPAD) && (len < width) && (len < PRINTF_NTOA_BUFFER_SIZE)) {
       buf[len++] = '0';
     }
+  }
+  while ((len < prec) && (len < PRINTF_NTOA_BUFFER_SIZE)) {
+    buf[len++] = '0';
   }
 
   // handle hash

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -1503,6 +1503,9 @@ TEST_CASE("misc", "[]" ) {
   test::sprintf(buffer, "%*sx", -3, "hi");
   REQUIRE(!strcmp(buffer, "hi x"));
 
+  test::sprintf(buffer, "%-20.5i", 123);
+  REQUIRE(!strcmp(buffer, "00123               "));
+
 #ifndef PRINTF_DISABLE_SUPPORT_EXPONENTIAL
   test::sprintf(buffer, "%.*g", 2, 0.33333333);
   REQUIRE(!strcmp(buffer, "0.33"));


### PR DESCRIPTION
Bug fix. Precision padding of integers failed in combination with left alignment.

printf(buffer, "%-20.5i", 123);
output "123                 "
not "00123               "

Added a test to the 'misc' tests in test_suite.cpp
Moved precision padding outside of the if (!(flags & FLAGS_LEFT))  condition block.
