### PR TITLE
feat: allow skip the dependency on _putchar

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -149,9 +149,13 @@ static inline void _out_null(char character, void* buffer, size_t idx, size_t ma
 static inline void _out_char(char character, void* buffer, size_t idx, size_t maxlen)
 {
   (void)buffer; (void)idx; (void)maxlen;
+#ifdef PRINTF_NO_PUTCHAR
+  (void)character;
+#else
   if (character) {
     _putchar(character);
   }
+#endif
 }
 
 


### PR DESCRIPTION
Currently, it is required to implement _putchar even don't ever plan using it. This PR adds a config option to skip the calling on it.

---

With the options `-dead_strip` on MacOS or `-Wl,-gc-sections` on Linux, the symbol does being stripped out thus no need to implement it. But these options have their own side effects, which won't always fit. (e.g. `-Wl,-gc-sections` would break `_init`)
